### PR TITLE
Fix link

### DIFF
--- a/docs/salamander_tutorial.md
+++ b/docs/salamander_tutorial.md
@@ -18,7 +18,7 @@ Salamander tracks the AWS _spot_ price +26%. Prices at time of writing:
 
 ## Step 1: Create an account
 
-Visit https://salamander.ai, click "Get Started", fill-in the form & add your card details.
+Visit [https://salamander.ai](https://salamander.ai), click "Get Started", fill-in the form & add your card details.
 
 ![](./images/salamander/create_account.png)
 


### PR DESCRIPTION
Just writing "https://salamander.ai" doesn't convert the text to an actual link on http://course-v3.fast.ai/salamander_tutorial