### PR TITLE
Add "aws credits" subsection

### DIFF
--- a/docs/start_salamander.md
+++ b/docs/start_salamander.md
@@ -16,6 +16,10 @@ Salamander tracks the AWS _spot_ price +26%. Prices at time of writing:
 - K80: $0.36 per hour
 - V100: $1.32 per hour
 
+#### AWS Credits
+
+If you have an AWS promo code you can redeem 75% of it's value for Salamander credits. Signup, email [support@salamander.ai](mailto:support@salamander.ai) with the subject "AWS CREDITS" & include your promo code in the email body. It will take up to 24 hours for the credits to appear in your Salamander account.
+
 ## Step 1: Create an account
 
 Visit [https://salamander.ai](https://salamander.ai), click "Get Started", fill-in the form & add your card details.


### PR DESCRIPTION
I thought all ~3000 students were going to receive AWS credits, but now I've learned it's only 200 I'm happy to manually import all of their credits into Salamander on a 24h timescale if you'd like.

Tried automating to make instant but didn't finish.