### PR TITLE
Updated the boot disk size based on GCP advice

### DIFF
--- a/docs/start_gcp.md
+++ b/docs/start_gcp.md
@@ -90,7 +90,7 @@ gcloud compute instances create $INSTANCE_NAME \
         --maintenance-policy=TERMINATE \
         --accelerator='type=nvidia-tesla-p100,count=1' \
         --machine-type=$INSTANCE_TYPE \
-        --boot-disk-size=120GB \
+        --boot-disk-size=200GB \
         --metadata='install-nvidia-driver=True' \
         --preemptible
 ```


### PR DESCRIPTION
It is noted in the GCP [Storage Options](http://google.com) docs that "Performance on persistent disks is predictable, scales linearly, and is directly related to boot disk size. A boot disk smaller than 200GB will result in a poor experience."