### PR TITLE
Making markdown comment match code

### DIFF
--- a/nbs/dl1/lesson1-pets.ipynb
+++ b/nbs/dl1/lesson1-pets.ipynb
@@ -252,7 +252,7 @@
    "source": [
     "Now we will start training our model. We will use a [convolutional neural network](http://cs231n.github.io/convolutional-networks/) backbone and a fully connected head with a single hidden layer as a classifier. Don't know what these things mean? Not to worry, we will dive deeper in the coming lessons. For the moment you need to know that we are building a model which will take images as input and will output the predicted probability for each of the categories (in this case, it will have 37 ouptuts).\n",
     "\n",
-    "We will train for 5 epochs (5 cycles through all our data)."
+    "We will train for 4 epochs (4 cycles through all our data)."
    ]
   },
   {


### PR DESCRIPTION
I noticed that the first training example uses 4 iterations through the data - but the comment says 5. 