### PR TITLE
Add docs, "Start Notebook" script. (import fastai on a restarted notebook now works)

### DIFF
--- a/docs/start_sagemaker.md
+++ b/docs/start_sagemaker.md
@@ -38,6 +38,34 @@ The instance we suggest, ml.p2.xlarge, is $1.26 an hour. The hourly rate is depe
 
     <img alt="fastai" src="/images/sagemaker/05.png" class="screenshot">
 
+1. In the *Scripts* section, click *Start notebook*. 
+
+    <img alt="create" src="/images/sagemaker/06.png" class="screenshot">
+
+1. Paste the following to replace the script shown:
+
+    ```bash
+    #!/bin/bash
+    set -e
+
+    echo "Creating fast.ai conda enviornment"
+    cat > /home/ec2-user/fastai-setup.sh << EOF
+    #!/bin/bash
+    cd /home/ec2-user/SageMaker
+    source activate envs/fastai
+    echo "Finished creating fast.ai conda environment"
+    ipython kernel install --name 'fastai' --display-name 'Python 3' --user
+    EOF
+
+    chown ec2-user:ec2-user /home/ec2-user/fastai-setup.sh
+    chmod 755 /home/ec2-user/fastai-setup.sh
+
+    sudo -i -u ec2-user bash << EOF
+    echo "Creating fast.ai conda env in background process."
+    nohup /home/ec2-user/fastai-setup.sh &
+    EOF
+    ```
+
 1. In the *Scripts* section, click *Create notebook*. **NB:** ensure you are in the *Create notebook* section, otherwise your instance will be reconfigured from scratch every time you start it!
 
     <img alt="create" src="/images/sagemaker/06.png" class="screenshot">
@@ -111,6 +139,8 @@ The instance we suggest, ml.p2.xlarge, is $1.26 an hour. The hourly rate is depe
 1. Click on the *course-v3* folder, and your screen should look like this:
 
     <img alt="nb tuto" src="/images/jupyter.png" class="screenshot">
+    
+1. When you start the notebook, if prompted (not expected if all is well) to select a kernel choose *Python 3*. If you aren't prompted, you can verify the kernel name on the top right hand side, you can change the attahed kernel through the menu *Kernel > Change Kernel*
 
 1. Go back to the [first page](index.html) to see how to use this jupyter notebook and run the jupyter notebook tutorial. Come back here once you're finished and *don't forget to stop your instance* with the next step.
 


### PR DESCRIPTION
The current docs are lacking. 
The following breaks. 
1. Create notebook and start for the first time, all is well.
2. Stop Notebook.
3. Start Notebook.
4. Try to run notebook with any kernel attached. 
Fail :
" from fastai import *"
ModuleNotFoundError: No module named 'fastai'

This solves the issue.
TESTED restarted notebook, verified that this works and is broken without this.