### PR TITLE
Update directory in step 4 of start_gcp.md

### DIFF
--- a/docs/start_gcp.md
+++ b/docs/start_gcp.md
@@ -166,7 +166,7 @@ Now your command line which should show a prompt along the lines of `jupyter@my-
 You should make sure Github is configured and pull from the repository. You can do this by typing the following lines:
 
 ``` basg
-cd tutorials/fastai
+cd tutorials/fastai/course-v3
 git checkout .
 git pull
 ```


### PR DESCRIPTION
In Step 4, `git pull` should be run in `tutorials/fastai/course-v3` instead of `tutorials/fastai/`.