### PR TITLE
Corrected notebook tutorial typos, line 282 '<' -> '>' and line 353 '[]' -> '[ ]'

### DIFF
--- a/nbs/dl1/00_notebook_tutorial.ipynb
+++ b/nbs/dl1/00_notebook_tutorial.ipynb
@@ -279,7 +279,7 @@
     "1. *Italics*: Surround your text with '\\_' or '\\*'\n",
     "2. **Bold**: Surround your text with '\\__' or '\\**'\n",
     "3. `inline`: Surround your text with '\\`'\n",
-    "4.  > blockquote: Place '\\<' before your text.\n",
+    "4.  > blockquote: Place '\\>' before your text.\n",
     "5.  [Links](http://course-v3.fast.ai/): Surround the text you want to link with '\\[\\]' and place the link adjacent to the text, surrounded with '()'\n"
    ]
   },
@@ -350,7 +350,7 @@
     "    - [x] Writing\n",
     "    - [x] Modes\n",
     "    - [x] Other Considerations\n",
-    "- [] Change the world"
+    "- [ ] Change the world"
    ]
   },
   {


### PR DESCRIPTION
corrected typos for:
blockquote (line 282)
track list unchecked bos (line 353)