### PR TITLE
[colab] Fix setup script link.

### DIFF
--- a/docs/start_colab.md
+++ b/docs/start_colab.md
@@ -32,7 +32,7 @@ If you are returning to work and have previously completed the steps below, plea
 1. Before you start using your notebook, you need to install the necessary packages. You can do this by creating a code cell, and running:
 
     ```bash
-     !curl http://course-v3.fast.ai/setup/colab | bash
+     !curl https://course-v3.fast.ai/setup/colab | bash
     ```
 
     <img alt="create" src="/images/colab/05.png" class="screenshot">


### PR DESCRIPTION
Using the http link seems to produce the following error sometimes:

<img width="688" alt="screen shot 2018-10-29 at 3 47 21 pm" src="https://user-images.githubusercontent.com/2343554/47684976-10e5bd80-db92-11e8-8794-9496b94dca0a.png">

Using the httpS link is more reliable and should always work.