### PR TITLE
Wrong 'cd' path before git

### DIFF
--- a/docs/update_gcp.md
+++ b/docs/update_gcp.md
@@ -37,7 +37,7 @@ Once this is done, you can access your jupyter notebook at [localhost:8080/tree]
  To update the course repo, go in your terminal and run those two instructions:
 
 ``` bash
-cd tutorials/fastai
+cd tutorials/fastai/course-v3
 git pull
 ```
 


### PR DESCRIPTION
The original `cd` command leads to error in the next step when calling git

```
  jupyter@my-fastai-instance:~/tutorials/fastai$ git pull
  fatal: Not a git repository (or any of the parent directories): .git
```

That is because we must go one level deeper - into `course-v3` subfolder.