### PR TITLE
Update update_gcp.md

### DIFF
--- a/docs/update_gcp.md
+++ b/docs/update_gcp.md
@@ -37,7 +37,7 @@ Once this is done, you can access your jupyter notebook at [localhost:8080/tree]
  To update the course repo, go in your terminal and run those two instructions:
 
 ``` bash
-cd tutorials/fastai
+cd tutorials/fastai/course-v3
 git pull
 ```
 


### PR DESCRIPTION
Added "course-v3" to cd tutorials/fastai/ so it's now cd tutorials/fastai/course-v3.

Using only cd tutorials/fastai/ gives the error:
" fatal: Not a git repository (or any of the parent directories): .git"