### PR TITLE
lesson3-planet nb: Fix missing ImageMultiDataset in initial databunch setup for 

### DIFF
--- a/nbs/dl1/lesson3-planet.ipynb
+++ b/nbs/dl1/lesson3-planet.ipynb
@@ -271,7 +271,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data = (src.datasets()\n",
+    "data = (src.datasets(ImageMultiDataset)\n",
     "        .transform(tfms, size=128)\n",
     "        .databunch().normalize(imagenet_stats))"
    ]


### PR DESCRIPTION
Minifix to todays lessons planet notebook.
The text mentions explicitly that ImageMultiDataset has to be used, but it was missing in the code.
The second databunch setup for larger image size correctly contains it already.