### PR TITLE
fix wrong dataset pass into ImageDeleter

### DIFF
--- a/nbs/dl1/lesson2-download.ipynb
+++ b/nbs/dl1/lesson2-download.ipynb
@@ -718,7 +718,7 @@
     }
    ],
    "source": [
-    "fd = ImageDeleter(data, idxs)\n"
+    "fd = ImageDeleter(data.valid_ds, idxs)\n"
    ]
   },
   {
@@ -1120,6 +1120,18 @@
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
I think currently the ImageDeleter takes in a Dataset instead of a DataBunch, What I have experienced is it is deleting my training dataset while I pass in the validation idx.

See this thread.
https://forums.fast.ai/t/lesson-2-in-class-discussion/28632/740?u=nok

Reproduce:
You can reproduce this by creating a  validation set with one image only, then use the file deleter to delete it, see if it is still here.

