### PR TITLE
Updated lesson3-planet notebook

### DIFF
--- a/nbs/dl1/lesson3-planet.ipynb
+++ b/nbs/dl1/lesson3-planet.ipynb
@@ -97,7 +97,7 @@
    ],
    "source": [
     "path = Config.data_path()/'planet'\n",
-    "path.mkdir(exist_ok=True)\n",
+    "path.mkdir(parents=True, exist_ok=True)\n",
     "path"
    ]
   },


### PR DESCRIPTION
(Please refer to the commit for code context)

Here `path` is `/home/jupyter/.fastai/data/planet`.
Recall that the default behavior of the `Path.mkdir` function will raise `FileNotFoundError` when there is a missing parent.
In a freshly installed new instance, there will not be a `data` directory under `.fastai` directory. Thus, the current command will raise `FileNotFoundError`.

Here is what the Python will raise:
`FileNotFoundError: [Errno 2] No such file or directory: '/home/jupyter/.fastai/data/planet'`

After adding an argument `parents=True`, any missing parents of this path are created as needed, which will produce the desired result in a new instance.