### PR TITLE
Create instance with SSD instead of hard drive

### DIFF
--- a/docs/start_gcp.md
+++ b/docs/start_gcp.md
@@ -125,6 +125,7 @@ gcloud compute instances create $INSTANCE_NAME \
         --accelerator="type=nvidia-tesla-p4,count=1" \
         --machine-type=$INSTANCE_TYPE \
         --boot-disk-size=200GB \
+        --boot-disk-type="pd-ssd" \
         --metadata="install-nvidia-driver=True" \
         --preemptible
 ```


### PR DESCRIPTION
`gcloud compute instances create` by default creates normal hard drive. Add an argument to make it create the instance with SSD.