### PR TITLE
add error_rate import

### DIFF
--- a/nbs/dl1/lesson1-pets.ipynb
+++ b/nbs/dl1/lesson1-pets.ipynb
@@ -42,7 +42,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from fastai.vision import *"
+    "from fastai.vision import *\n",
+    "from fastai.metrics import error_rate"
    ]
   },
   {
@@ -1100,6 +1101,18 @@
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
When running this line, there is an error thrown about `error_rate` not defined:

```python
learn = create_cnn(data, models.resnet34, metrics=error_rate)
```

Error rate needs to be imported.