### PR TITLE
fixing reference to deprecated code

### DIFF
--- a/nbs/dl1/lesson3-planet.ipynb
+++ b/nbs/dl1/lesson3-planet.ipynb
@@ -240,7 +240,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To put this in a `DataBunch` while using the [data block API](https://docs.fast.ai/data_block.html), we then need to using `ImageMultiDataset` (and not `ImageClassificationDataset`). This will make sure the model created has the proper loss function to deal with the multiple classes."
+    "To put this in a `DataBunch` while using the [data block API](https://docs.fast.ai/data_block.html), we then need to using `ImageItemList` (and not `ImageDataBunch`). This will make sure the model created has the proper loss function to deal with the multiple classes."
    ]
   },
   {


### PR DESCRIPTION
fixing reference to deprecated code, ImageMultiDataset` and  `ImageClassificationDataset` are no longer parts of the library.