### PR TITLE
Update deployment docs to use the `.pkl` file 

### DIFF
--- a/docs/css/customstyles.css
+++ b/docs/css/customstyles.css
@@ -1411,7 +1411,6 @@ h4 code {
     border: 2px solid
 }
 
-.provider-logo {
-    width: 100px;
-    height: 100px;
+.render-logo {
+    width: 109px;
 }

--- a/docs/css/customstyles.css
+++ b/docs/css/customstyles.css
@@ -1411,6 +1411,7 @@ h4 code {
     border: 2px solid
 }
 
-.render-logo {
-    width: 109px;
+.provider-logo {
+    width: 100px;
+    height: 100px;
 }

--- a/docs/css/customstyles.css
+++ b/docs/css/customstyles.css
@@ -1411,6 +1411,6 @@ h4 code {
     border: 2px solid
 }
 
-.render-logo {
+.provider-logo {
     width: 109px;
 }

--- a/docs/deployment_render.md
+++ b/docs/deployment_render.md
@@ -3,7 +3,7 @@ title: "Deploying on Render"
 sidebar: home_sidebar
 ---
 
-<img alt="Render" src="/images/render/render.svg" class="render-logo" width="300">
+<img alt="Render" src="/images/render/render.svg" class="provider-logo" width="300">
 
 This is quick guide to deploy your trained models on [Render](https://render.com) in just a few clicks. It comes with a [starter repo](https://github.com/render-examples/fastai-v3) that uses Jeremy's Bear Image Classification model from Lesson 2.
 

--- a/docs/deployment_render.md
+++ b/docs/deployment_render.md
@@ -3,7 +3,11 @@ title: "Deploying on Render"
 sidebar: home_sidebar
 ---
 
+<<<<<<< HEAD
 <img alt="Render" src="/images/render/render.svg" class="provider-logo" width="300">
+=======
+<img alt="Render" src="/images/render/render.png" class="provider-logo">
+>>>>>>> Add pricing and logo class
 
 This is quick guide to deploy your trained models on [Render](https://render.com) in just a few clicks. It comes with a [starter repo](https://github.com/render-examples/fastai-v3) that uses Jeremy's Bear Image Classification model from Lesson 2.
 

--- a/docs/deployment_render.md
+++ b/docs/deployment_render.md
@@ -3,11 +3,7 @@ title: "Deploying on Render"
 sidebar: home_sidebar
 ---
 
-<<<<<<< HEAD
 <img alt="Render" src="/images/render/render.svg" class="provider-logo" width="300">
-=======
-<img alt="Render" src="/images/render/render.png" class="provider-logo">
->>>>>>> Add pricing and logo class
 
 This is quick guide to deploy your trained models on [Render](https://render.com) in just a few clicks. It comes with a [starter repo](https://github.com/render-examples/fastai-v3) that uses Jeremy's Bear Image Classification model from Lesson 2.
 

--- a/docs/deployment_render.md
+++ b/docs/deployment_render.md
@@ -27,7 +27,7 @@ If you just want to test initial deployment on Render, the starter repo is set u
 
 ### Upload your trained model file
 
-Upload your trained model file (for example `stage-2.pth`) to a cloud service like Google Drive or Dropbox. Copy the download link for the file. 
+Upload the trained model file created with `learner.export` (for example `export.pkl`) to a cloud service like Google Drive or Dropbox. Copy the download link for the file.
 
 **Note** the download link should start the file download directly&mdash;and is typically different from the share link (which presents you with a view to download the file). Use [this link generator](https://syncwithtech.blogspot.com/p/direct-download-link-generator.html) if you need help.
 


### PR DESCRIPTION
The latest version of `fastai` works with the `.pkl` files generated by `.export`. Updating the docs to be current.