### PR TITLE
pytorch nightly no longer needed

### DIFF
--- a/docs/setup/colab
+++ b/docs/setup/colab
@@ -1,7 +1,6 @@
 #!/bin/bash
 if [ ! -d course-v3 ]; then
         pip install pillow==4.1.1 --upgrade
-        pip install torch_nightly -f https://download.pytorch.org/whl/nightly/cu92/torch_nightly.html --upgrade
 
         sed -n -e '/^tmpfs \/dev\/shm tmpfs defaults,size=/!p' -e '$atmpfs \/dev\/shm tmpfs defaults,size=1g 0 0' -i /etc/fstab
         mount -o remount /dev/shm


### PR DESCRIPTION
Not only is pytorch nightly not needed, but it gets overwritten when you install fastai later in the colab script.  Thus the user ends up downloading pytorch twice.  See issue #140 