### PR TITLE
Update Render links

### DIFF
--- a/docs/deployment_render.md
+++ b/docs/deployment_render.md
@@ -7,7 +7,7 @@ sidebar: home_sidebar
 
 This is quick guide to deploy your trained models on [Render](https://render.com) in just a few clicks. It comes with a [starter repo](https://github.com/render-examples/fastai-v3) that uses Jeremy's Bear Image Classification model from Lesson 2.
 
-The starter app is deployed at [https://fastai-v3.app.render.com](https://fastai-v3.app.render.com).
+The starter app is deployed at [https://fastai-v3.onrender.com](https://fastai-v3.onrender.com).
 
 ## One-time setup
 
@@ -17,7 +17,7 @@ Fork [https://github.com/render-examples/fastai-v3](https://github.com/render-ex
 
 ### Create a Render account
 
-Sign up at [Render](https://dashboard.render.com/register?i=fastai-v3) using invite code `fastai-v3`.
+Sign up at [Render](https://render.com/i/fastai-v3) using invite code `fastai-v3`.
 
 Render web services cost $5 per month and are prorated by the second. All new accounts start out with $25 in credits.
 
@@ -51,7 +51,7 @@ Make sure to keep the GitHub repo you created above current. Render integrates w
 
 ## Test your app
 
-Your app's URL will look like `https://service-name.app.render.com`. You can also monitor the service logs as you test your app.
+Your app's URL will look like `https://service-name.onrender.com`. You can also monitor the service logs as you test your app.
 
 ## Local testing
 

--- a/fastai-video-browser/src/assets/dl-1-2/notes.md
+++ b/fastai-video-browser/src/assets/dl-1-2/notes.md
@@ -13,7 +13,7 @@ I'll demonstrate all these steps as I create a model that can take on the vital 
 
 We've had some great additions since this lesson was recorded, so be sure to check out:
 
-- The *production starter kits* on the course web site, such as [this one](https://course-v3.fast.ai/deployment_render.html) for deploying to [Render](https://render.com).
+- The *production starter kits* on the course web site, such as [this one](https://course-v3.fast.ai/deployment_render.html) for deploying to Render.com.
 - The new interactive GUI in the lesson notebook for using the model to find and fix mislabeled or incorrectly-collected images.
 
 In the second half of the lesson we'll train a simple model from scratch, creating our own *gradient descent* loop. In the process, we'll be learning lots of new jargon, so be sure you've got a good place to take notes, since we'll be referring to this new terminology throughout the course (and there will be lots more introduced in every lesson from here on).

--- a/fastai-video-browser/src/assets/dl-1-2/notes.md
+++ b/fastai-video-browser/src/assets/dl-1-2/notes.md
@@ -13,7 +13,7 @@ I'll demonstrate all these steps as I create a model that can take on the vital 
 
 We've had some great additions since this lesson was recorded, so be sure to check out:
 
-- The *production starter kits* on the course web site, such as [this one](https://course-v3.fast.ai/deployment_render.html) for deploying to Render.com
+- The *production starter kits* on the course web site, such as [this one](https://course-v3.fast.ai/deployment_render.html) for deploying to [Render](https://render.com).
 - The new interactive GUI in the lesson notebook for using the model to find and fix mislabeled or incorrectly-collected images.
 
 In the second half of the lesson we'll train a simple model from scratch, creating our own *gradient descent* loop. In the process, we'll be learning lots of new jargon, so be sure you've got a good place to take notes, since we'll be referring to this new terminology throughout the course (and there will be lots more introduced in every lesson from here on).


### PR DESCRIPTION
We've moved `.app.render.com` links to `.onrender.com`.