### PR TITLE
Update Gradient° Promo Code

### DIFF
--- a/docs/start_gradient.md
+++ b/docs/start_gradient.md
@@ -84,7 +84,8 @@ For more details, updating the course and the fastai library see "[Returning to 
 The `/storage` folder is your [Persistent Storage](https://support.paperspace.com/hc/en-us/articles/360001468133-Persistent-Storage). Files placed here are available across all Notebooks, Jobs, and Linux VMs (currently free of charge). This repository is perfect for storing datasets, models etc. Note: Persistent Storage is region specific (you'll see the storage region options when creating Notebooks and Jobs).
 
 ### Promotional credit
-Paperspace provides $10 of free Gradient° credit. This code is to be used for Fast.ai students only. In your console, click on Billing and enter the promo code at the bottom right. The promo code for this course is: **FASTAIGR45T**.
+Paperspace provides $10 of free Gradient° credit. This code is to be used for Fast.ai students only. In your console, click on Billing and enter the promo code at the bottom right. The promo code for this course is: **FASTAIGR19**. 
+*Note: the code is valid until Jan 1, 2020*
 
 Note: If you opt for a Gradient 1 Subscription, promotional credit does not apply. [Learn more about Gradient Subscription levels here](https://support.paperspace.com/hc/en-us/articles/360002068913-Gradient-Subscriptions).
 


### PR DESCRIPTION
I generated the promo code Dillon submitted last night but failed to make it Gradient° specific
This edit has a slightly different Gradient° Promo Code that IS Gradient°-specific
Also to avoid confusion from past expired codes, I added a note about when this one expires in line 88