### PR TITLE
Replace course-v3 URLs

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -2,7 +2,7 @@
 
 ## Do I need a GPU to do deep learning?
 
-Yes. GPU's are ~10/15 times faster than CPU's in running neural networks. You will need a GPU-enabled server but don't worry, we've got you covered. Check out our tutorials for renting deep learning servers or Jupyter Notebook Platforms [here](http://course-v3.fast.ai).
+Yes. GPU's are ~10/15 times faster than CPU's in running neural networks. You will need a GPU-enabled server but don't worry, we've got you covered. Check out our tutorials for renting deep learning servers or Jupyter Notebook Platforms [here](http://course.fast.ai).
 
 ## What is the difference between a Jupyter Notebook Platform and a Deep Learning Server?
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -2,7 +2,7 @@
 
 ## Do I need a GPU to do deep learning?
 
-Yes. GPU's are ~10/15 times faster than CPU's in running neural networks. You will need a GPU-enabled server but don't worry, we've got you covered. Check out our tutorials for renting deep learning servers or Jupyter Notebook Platforms [here](http://course.fast.ai).
+Yes. GPU's are ~10/15 times faster than CPU's in running neural networks. You will need a GPU-enabled server but don't worry, we've got you covered. Check out our tutorials for renting deep learning servers or Jupyter Notebook Platforms [here](https://course.fast.ai).
 
 ## What is the difference between a Jupyter Notebook Platform and a Deep Learning Server?
 

--- a/docs/docs-dev-build.txt
+++ b/docs/docs-dev-build.txt
@@ -1,6 +1,6 @@
-*** How to maintain https://course-v3.fast.ai/ ***
+*** How to maintain https://course.fast.ai/ ***
 
-docs/ is automatically mapped to https://course-v3.fast.ai/ so any changes committed to git will instantly appear on https://course-v3.fast.ai/
+docs/ is automatically mapped to https://course.fast.ai/ so any changes committed to git will instantly appear on https://course.fast.ai/
 
 * When a file is added/removed/renamed adjust:
   1. docs/_data/sidebars/home_sidebar.yml (sidebar menu)

--- a/docs/setup/sagemaker-cfn.yml
+++ b/docs/setup/sagemaker-cfn.yml
@@ -23,7 +23,7 @@ Resources:
             Fn::Base64: 
               !Sub |
                 #!/bin/bash
-                wget -N https://course-v3.fast.ai/setup/sagemaker-create
+                wget -N https://course.fast.ai/setup/sagemaker-create
                 chown ec2-user sagemaker-create
                 chmod u+x sagemaker-create
                 sudo -H -u ec2-user -i bash -c 'nohup ./sagemaker-create &'
@@ -33,7 +33,7 @@ Resources:
             Fn::Base64:
               !Sub |          
                 #!/bin/bash
-                wget -N https://course-v3.fast.ai/setup/sagemaker-start
+                wget -N https://course.fast.ai/setup/sagemaker-start
                 chown ec2-user sagemaker-start
                 chmod u+x sagemaker-start
                 sudo -H -u ec2-user -i bash -c './sagemaker-start'

--- a/docs/start_aws.md
+++ b/docs/start_aws.md
@@ -10,7 +10,7 @@ sidebar: home_sidebar
 
 AWS EC2 provides preconfigured machine images called [DLAMI](https://aws.amazon.com/machine-learning/amis/), which are servers hosted by Amazon that are specially dedicated to Deep Learning tasks. Setting up an AWS EC2 instance, even with DLAMI, can be daunting. But don't worry, we got you covered. In fact, Amazon has a sweet [step by step guide](https://aws.amazon.com/getting-started/tutorials/get-started-dlami/) to set it up and we are going to draw heavily from their tutorial.
 
-If you are returning to work and have previously completed the steps below, please go to the [returning to work](http://course.fast.ai/update_aws.html) section.
+If you are returning to work and have previously completed the steps below, please go to the [returning to work](https://course.fast.ai/update_aws.html) section.
 
 ## Pricing
 A `p2.xlarge` instance in Amazon which is what we suggest, is [$0.9 an hour](https://aws.amazon.com/ec2/instance-types/p2/).

--- a/docs/start_aws.md
+++ b/docs/start_aws.md
@@ -10,7 +10,7 @@ sidebar: home_sidebar
 
 AWS EC2 provides preconfigured machine images called [DLAMI](https://aws.amazon.com/machine-learning/amis/), which are servers hosted by Amazon that are specially dedicated to Deep Learning tasks. Setting up an AWS EC2 instance, even with DLAMI, can be daunting. But don't worry, we got you covered. In fact, Amazon has a sweet [step by step guide](https://aws.amazon.com/getting-started/tutorials/get-started-dlami/) to set it up and we are going to draw heavily from their tutorial.
 
-If you are returning to work and have previously completed the steps below, please go to the [returning to work](http://course-v3.fast.ai/update_aws.html) section.
+If you are returning to work and have previously completed the steps below, please go to the [returning to work](http://course.fast.ai/update_aws.html) section.
 
 ## Pricing
 A `p2.xlarge` instance in Amazon which is what we suggest, is [$0.9 an hour](https://aws.amazon.com/ec2/instance-types/p2/).

--- a/docs/start_azure.md
+++ b/docs/start_azure.md
@@ -9,7 +9,7 @@ sidebar: home_sidebar
 
 This tutorial explains how to set up a DSVM to use Pytorch v1 and fastai v1.
 
-If you are returning to work and have previously completed the steps below, please go to the [returning to work](http://course.fast.ai/update_azure.html) section.
+If you are returning to work and have previously completed the steps below, please go to the [returning to work](https://course.fast.ai/update_azure.html) section.
 
 ## Pricing
 We suggest using a Standard_NC6 instance in Azure which has one NVidia K80 GPU and six CPU cores. This instance will incur about $0.90 per hour of [compute charges](https://azure.microsoft.com/en-us/pricing/details/virtual-machines/linux/), or **$0.18** per hour if you use [low priority pre-emptable Standard_NC6 instances](https://azure.microsoft.com/en-us/pricing/details/virtual-machine-scale-sets/linux/) (see below for more information on this option).

--- a/docs/start_azure.md
+++ b/docs/start_azure.md
@@ -9,7 +9,7 @@ sidebar: home_sidebar
 
 This tutorial explains how to set up a DSVM to use Pytorch v1 and fastai v1.
 
-If you are returning to work and have previously completed the steps below, please go to the [returning to work](http://course-v3.fast.ai/update_azure.html) section.
+If you are returning to work and have previously completed the steps below, please go to the [returning to work](http://course.fast.ai/update_azure.html) section.
 
 ## Pricing
 We suggest using a Standard_NC6 instance in Azure which has one NVidia K80 GPU and six CPU cores. This instance will incur about $0.90 per hour of [compute charges](https://azure.microsoft.com/en-us/pricing/details/virtual-machines/linux/), or **$0.18** per hour if you use [low priority pre-emptable Standard_NC6 instances](https://azure.microsoft.com/en-us/pricing/details/virtual-machine-scale-sets/linux/) (see below for more information on this option).

--- a/docs/start_colab.md
+++ b/docs/start_colab.md
@@ -6,7 +6,7 @@ sidebar: home_sidebar
 
 This is a quick guide to starting v3 of the fast.ai course Practical Deep Learning for Coders using Colab. 
 
-If you are returning to work and have previously completed the steps below, please go to the [returning to work](http://course-v3.fast.ai/update_colab.html) section.
+If you are returning to work and have previously completed the steps below, please go to the [returning to work](http://course.fast.ai/update_colab.html) section.
 
 **NB: This is a free service that may not always be available, and requires extra steps to ensure your work is saved. Be sure to read the docs on the Colab web-site to ensure you understand the limitations of the system.**
 
@@ -32,7 +32,7 @@ If you are returning to work and have previously completed the steps below, plea
 1. Before you start using your notebook, you need to install the necessary packages. You can do this by creating a code cell, and running:
 
     ```bash
-     !curl https://course-v3.fast.ai/setup/colab | bash
+     !curl https://course.fast.ai/setup/colab | bash
     ```
 
     <img alt="create" src="/images/colab/05.png" class="screenshot">

--- a/docs/start_colab.md
+++ b/docs/start_colab.md
@@ -6,7 +6,7 @@ sidebar: home_sidebar
 
 This is a quick guide to starting v3 of the fast.ai course Practical Deep Learning for Coders using Colab. 
 
-If you are returning to work and have previously completed the steps below, please go to the [returning to work](http://course.fast.ai/update_colab.html) section.
+If you are returning to work and have previously completed the steps below, please go to the [returning to work](https://course.fast.ai/update_colab.html) section.
 
 **NB: This is a free service that may not always be available, and requires extra steps to ensure your work is saved. Be sure to read the docs on the Colab web-site to ensure you understand the limitations of the system.**
 

--- a/docs/start_crestle.md
+++ b/docs/start_crestle.md
@@ -10,7 +10,7 @@ sidebar: home_sidebar
 
 [Crestle.ai](https://www.crestle.ai/) is an effortless infrastructure for deep learning. Once you sign up you should be able to spin up a GPU enabled Jupyter notebook within a minute. There is no setup required on your part.
 
-If you are returning to work and have previously completed the steps below, please go to the [returning to work](http://course.fast.ai/update_crestle.html) section.
+If you are returning to work and have previously completed the steps below, please go to the [returning to work](https://course.fast.ai/update_crestle.html) section.
 
 ## Using crestle.ai for fast.ai v3 course
 
@@ -72,7 +72,7 @@ Now you should close the terminal window.
 
 ### Step 5: The datasets are already there - start coding!
 
-We have already mounted the [datasets](http://course.fast.ai/datasets) required for this course. You don't have to download them. This is about 35 GB worth of data ready for you to train your models on.
+We have already mounted the [datasets](https://course.fast.ai/datasets) required for this course. You don't have to download them. This is about 35 GB worth of data ready for you to train your models on.
 
 <img alt="" src="/images/crestle/datasets.png" class="screenshot">
 

--- a/docs/start_crestle.md
+++ b/docs/start_crestle.md
@@ -10,7 +10,7 @@ sidebar: home_sidebar
 
 [Crestle.ai](https://www.crestle.ai/) is an effortless infrastructure for deep learning. Once you sign up you should be able to spin up a GPU enabled Jupyter notebook within a minute. There is no setup required on your part.
 
-If you are returning to work and have previously completed the steps below, please go to the [returning to work](http://course-v3.fast.ai/update_crestle.html) section.
+If you are returning to work and have previously completed the steps below, please go to the [returning to work](http://course.fast.ai/update_crestle.html) section.
 
 ## Using crestle.ai for fast.ai v3 course
 

--- a/docs/start_floydhub.md
+++ b/docs/start_floydhub.md
@@ -6,7 +6,7 @@ sidebar: home_sidebar
 
 <img alt="" src="/images/floydhub/floydhubFastai.png">
 
-This is a quick guide to starting v3 of the Fast.ai course. With [FloydHub](https://www.floydhub.com), you get access to a dedicated JupyterLab instance. If you are returning to work and have previously completed the steps below, please go to the [returning to work](http://course.fast.ai/update_floydhub.html) section.
+This is a quick guide to starting v3 of the Fast.ai course. With [FloydHub](https://www.floydhub.com), you get access to a dedicated JupyterLab instance. If you are returning to work and have previously completed the steps below, please go to the [returning to work](https://course.fast.ai/update_floydhub.html) section.
 
 ## Pricing
 

--- a/docs/start_floydhub.md
+++ b/docs/start_floydhub.md
@@ -6,7 +6,7 @@ sidebar: home_sidebar
 
 <img alt="" src="/images/floydhub/floydhubFastai.png">
 
-This is a quick guide to starting v3 of the Fast.ai course. With [FloydHub](https://www.floydhub.com), you get access to a dedicated JupyterLab instance. If you are returning to work and have previously completed the steps below, please go to the [returning to work](http://course-v3.fast.ai/update_floydhub.html) section.
+This is a quick guide to starting v3 of the Fast.ai course. With [FloydHub](https://www.floydhub.com), you get access to a dedicated JupyterLab instance. If you are returning to work and have previously completed the steps below, please go to the [returning to work](http://course.fast.ai/update_floydhub.html) section.
 
 ## Pricing
 

--- a/docs/start_gcp.md
+++ b/docs/start_gcp.md
@@ -9,7 +9,7 @@ sidebar: home_sidebar
 
 This guide explains how to set up Google Cloud Platform (GCP) to use PyTorch 1.0.0 and fastai 1.0.2. At the end of this tutorial you will be able to use both in a GPU-enabled Jupyter Notebook environment.
 
-If you are returning to work and have previously completed the steps below, please go to the [returning to work](http://course.fast.ai/update_gcp.html) section.
+If you are returning to work and have previously completed the steps below, please go to the [returning to work](https://course.fast.ai/update_gcp.html) section.
 
 ## Pricing
 

--- a/docs/start_gcp.md
+++ b/docs/start_gcp.md
@@ -9,7 +9,7 @@ sidebar: home_sidebar
 
 This guide explains how to set up Google Cloud Platform (GCP) to use PyTorch 1.0.0 and fastai 1.0.2. At the end of this tutorial you will be able to use both in a GPU-enabled Jupyter Notebook environment.
 
-If you are returning to work and have previously completed the steps below, please go to the [returning to work](http://course-v3.fast.ai/update_gcp.html) section.
+If you are returning to work and have previously completed the steps below, please go to the [returning to work](http://course.fast.ai/update_gcp.html) section.
 
 ## Pricing
 

--- a/docs/start_gradient.md
+++ b/docs/start_gradient.md
@@ -10,7 +10,7 @@ This is a quick guide to starting v3 of the Fast.ai course. With [Gradient](http
 
 [Gradient](https://www.paperspace.com/gradient) is built on top of [Paperspace](https://www.paperspace.com/), a GPU-accelerated cloud platform. 
 
-If you are returning to work and have previously completed the steps below, please go to the [returning to work](http://course.fast.ai/update_gradient.html) section.
+If you are returning to work and have previously completed the steps below, please go to the [returning to work](https://course.fast.ai/update_gradient.html) section.
 
 ## Pricing
 

--- a/docs/start_gradient.md
+++ b/docs/start_gradient.md
@@ -10,7 +10,7 @@ This is a quick guide to starting v3 of the Fast.ai course. With [Gradient](http
 
 [Gradient](https://www.paperspace.com/gradient) is built on top of [Paperspace](https://www.paperspace.com/), a GPU-accelerated cloud platform. 
 
-If you are returning to work and have previously completed the steps below, please go to the [returning to work](http://course-v3.fast.ai/update_gradient.html) section.
+If you are returning to work and have previously completed the steps below, please go to the [returning to work](http://course.fast.ai/update_gradient.html) section.
 
 ## Pricing
 

--- a/docs/start_sagemaker.md
+++ b/docs/start_sagemaker.md
@@ -6,13 +6,13 @@ sidebar: home_sidebar
 
 This is a quick guide to starting v3 of the fast.ai course Practical Deep Learning for Coders using AWS SageMaker. 
 
-If you are returning to work and have previously completed the steps below, please go to the [returning to work](http://course-v3.fast.ai/update_sagemaker.html) section.
+If you are returning to work and have previously completed the steps below, please go to the [returning to work](http://course.fast.ai/update_sagemaker.html) section.
 
 We will use [AWS CloudFormation](https://aws.amazon.com/cloudformation/) to provision the SageMaker notebook lifecycle configuration and IAM role for the notebook instance. We will create the SageMaker notebook instance manually.
 
 ## Pricing
 
-The instance we suggest, ml.p2.xlarge, is $1.26 an hour. The hourly rate is dependent on the instance type selected, see all available types [here](https://aws.amazon.com/sagemaker/pricing/).  You will need to explicitely request a limit request to use this instance or the ml.p3.2xlarge instance, [here](https://course-v3.fast.ai/start_aws.html#step-2-request-service-limit ) Instances must be stopped to end billing.
+The instance we suggest, ml.p2.xlarge, is $1.26 an hour. The hourly rate is dependent on the instance type selected, see all available types [here](https://aws.amazon.com/sagemaker/pricing/).  You will need to explicitely request a limit request to use this instance or the ml.p3.2xlarge instance, [here](https://course.fast.ai/start_aws.html#step-2-request-service-limit ) Instances must be stopped to end billing.
 
 ## Getting Set Up
 

--- a/docs/start_sagemaker.md
+++ b/docs/start_sagemaker.md
@@ -6,7 +6,7 @@ sidebar: home_sidebar
 
 This is a quick guide to starting v3 of the fast.ai course Practical Deep Learning for Coders using AWS SageMaker. 
 
-If you are returning to work and have previously completed the steps below, please go to the [returning to work](http://course.fast.ai/update_sagemaker.html) section.
+If you are returning to work and have previously completed the steps below, please go to the [returning to work](https://course.fast.ai/update_sagemaker.html) section.
 
 We will use [AWS CloudFormation](https://aws.amazon.com/cloudformation/) to provision the SageMaker notebook lifecycle configuration and IAM role for the notebook instance. We will create the SageMaker notebook instance manually.
 

--- a/docs/start_salamander.md
+++ b/docs/start_salamander.md
@@ -9,7 +9,7 @@ sidebar: home_sidebar
 
 It takes about 1 minute to signup & launch a Salamander server. The servers include everything you need to complete the fastai v3 course. Once launched, you can jump straight to Jupyter Notebook or connect directly via ssh.
 
-If you are returning to work and have previously completed the steps below, please go to the [returning to work](http://course.fast.ai/update_salamander.html) section.
+If you are returning to work and have previously completed the steps below, please go to the [returning to work](https://course.fast.ai/update_salamander.html) section.
 
 ## Pricing
 

--- a/docs/start_salamander.md
+++ b/docs/start_salamander.md
@@ -9,7 +9,7 @@ sidebar: home_sidebar
 
 It takes about 1 minute to signup & launch a Salamander server. The servers include everything you need to complete the fastai v3 course. Once launched, you can jump straight to Jupyter Notebook or connect directly via ssh.
 
-If you are returning to work and have previously completed the steps below, please go to the [returning to work](http://course-v3.fast.ai/update_salamander.html) section.
+If you are returning to work and have previously completed the steps below, please go to the [returning to work](http://course.fast.ai/update_salamander.html) section.
 
 ## Pricing
 

--- a/docs/update_colab.md
+++ b/docs/update_colab.md
@@ -23,7 +23,7 @@ If you want to open a new course notebook you have not worked on before, click o
 To update packages and the course repo, create a code cell in your notebook and run:
 
 ```bash
-!curl https://course-v3.fast.ai/setup/colab | bash
+!curl https://course.fast.ai/setup/colab | bash
 ```
 
 <img alt="" src="/images/colab/07.png" class="screenshot">

--- a/files/dl-2019/notes/notes-1-1.md
+++ b/files/dl-2019/notes/notes-1-1.md
@@ -4,7 +4,7 @@ You can click the blue arrow buttons on the left and right panes to hide them an
 
 ## Overview
 
-To follow along with the lessons, you'll need to connect to a cloud GPU provider which has the fastai library installed (recommended; it should take only 5 minutes or so, and cost under $0.50/hour), or set up a computer with a suitable GPU yourself (which can take days to get working if you're not familiar with the process, so we don't recommend it). You'll also need to be familiar with the basics of the *Jupyter Notebook* environment we use for running deep learning experiments. Up to date tutorials and recommendations for these are available from the [course website](http://course.fast.ai).
+To follow along with the lessons, you'll need to connect to a cloud GPU provider which has the fastai library installed (recommended; it should take only 5 minutes or so, and cost under $0.50/hour), or set up a computer with a suitable GPU yourself (which can take days to get working if you're not familiar with the process, so we don't recommend it). You'll also need to be familiar with the basics of the *Jupyter Notebook* environment we use for running deep learning experiments. Up to date tutorials and recommendations for these are available from the [course website](https://course.fast.ai).
 
 The key outcome of this lesson is that we'll have trained an image classifier which can recognize pet breeds at state of the art accuracy. The key to this success is the use of *transfer learning*, which will be a key platform for much of this course. We'll also see how to analyze the model to understand its failure modes. In this case, we'll see that the places where the model is making mistakes is in the same areas that even breeding experts can make mistakes.
 
@@ -18,10 +18,10 @@ If you want to more deeply understand how PyTorch really works, you may want to 
 
 ### Lesson resources
 
-- [Course site](http://course.fast.ai), including setup guides for each platform
+- [Course site](https://course.fast.ai), including setup guides for each platform
 - [Course repo](https://github.com/fastai/course-v3)
 - [fastai docs](http://docs.fast.ai)
-- [fastai datasets](http://course.fast.ai/datasets)
+- [fastai datasets](https://course.fast.ai/datasets)
 - Notebooks:
   - [00_notebook_tutorial.ipynb](https://nbviewer.jupyter.org/github/fastai/course-v3/blob/master/nbs/dl1/00_notebook_tutorial.ipynb)
   - [lesson1-pets.ipynb](https://github.com/fastai/course-v3/blob/master/nbs/dl1/lesson1-pets.ipynb)

--- a/files/dl-2019/notes/notes-1-2.md
+++ b/files/dl-2019/notes/notes-1-2.md
@@ -13,7 +13,7 @@ I'll demonstrate all these steps as I create a model that can take on the vital 
 
 We've had some great additions since this lesson was recorded, so be sure to check out:
 
-- The *production starter kits* on the course web site, such as [this one](https://course-v3.fast.ai/deployment_render.html) for deploying to Render.com
+- The *production starter kits* on the course web site, such as [this one](https://course.fast.ai/deployment_render.html) for deploying to Render.com
 - The new interactive GUI in the lesson notebook for using the model to find and fix mislabeled or incorrectly-collected images.
 
 In the second half of the lesson we'll train a simple model from scratch, creating our own *gradient descent* loop. In the process, we'll be learning lots of new jargon, so be sure you've got a good place to take notes, since we'll be referring to this new terminology throughout the course (and there will be lots more introduced in every lesson from here on).

--- a/files/dl-2019/notes/notes-1-3.md
+++ b/files/dl-2019/notes/notes-1-3.md
@@ -33,7 +33,7 @@ What if your dependent variable is a continuous value, instead of a category? We
 -- [Introduction to Machine Learning for Coders](https://course.fast.ai/ml) taught by @jeremy
 -- [Machine Learning](https://www.coursera.org/learn/machine-learning) taught by Andrew Ng (coursera)
 - [Video Browser with Searchable Transcripts](http://videos.fast.ai/) Password: deeplearningSF2018 (do not share outside the forum group) -  [PRs welcome.]( https://github.com/zcaceres/fastai-video-browser)
-- [Quick and easy model deployment](https://course-v3.fast.ai/deployment_zeit.html) using Zeit Now
+- [Quick and easy model deployment](https://course.fast.ai/deployment_zeit.html) using Zeit Now
 - [Introduction to Kaggle API in Google Colab (Part-I)](https://mmiakashs.github.io/blog/2018-09-20-kaggle-api-google-colab/) tutorial by @mmiakashs
 - [Data block API](https://docs.fast.ai/data_block.html)
 - [Python partials](https://docs.python.org/3/library/functools.html#functools.partial)

--- a/nbs/dl1/00_notebook_tutorial.ipynb
+++ b/nbs/dl1/00_notebook_tutorial.ipynb
@@ -232,7 +232,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "4. You may need to use a terminal in a Jupyter Notebook environment (for example to git pull on a repository). That is very easy to do, just press 'New' in your Home directory and 'Terminal'. Don't know how to use the Terminal? We made a tutorial for that as well. You can find it [here](http://course.fast.ai/terminal_tutorial.html)."
+    "4. You may need to use a terminal in a Jupyter Notebook environment (for example to git pull on a repository). That is very easy to do, just press 'New' in your Home directory and 'Terminal'. Don't know how to use the Terminal? We made a tutorial for that as well. You can find it [here](https://course.fast.ai/terminal_tutorial.html)."
    ]
   },
   {
@@ -282,7 +282,7 @@
     "2. **Bold**: Surround your text with '\\__' or '\\**'\n",
     "3. `inline`: Surround your text with '\\`'\n",
     "4.  > blockquote: Place '\\>' before your text.\n",
-    "5.  [Links](http://course.fast.ai/): Surround the text you want to link with '\\[\\]' and place the link adjacent to the text, surrounded with '()'\n"
+    "5.  [Links](https://course.fast.ai/): Surround the text you want to link with '\\[\\]' and place the link adjacent to the text, surrounded with '()'\n"
    ]
   },
   {

--- a/nbs/dl1/00_notebook_tutorial.ipynb
+++ b/nbs/dl1/00_notebook_tutorial.ipynb
@@ -232,7 +232,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "4. You may need to use a terminal in a Jupyter Notebook environment (for example to git pull on a repository). That is very easy to do, just press 'New' in your Home directory and 'Terminal'. Don't know how to use the Terminal? We made a tutorial for that as well. You can find it [here](http://course-v3.fast.ai/terminal_tutorial.html)."
+    "4. You may need to use a terminal in a Jupyter Notebook environment (for example to git pull on a repository). That is very easy to do, just press 'New' in your Home directory and 'Terminal'. Don't know how to use the Terminal? We made a tutorial for that as well. You can find it [here](http://course.fast.ai/terminal_tutorial.html)."
    ]
   },
   {
@@ -282,7 +282,7 @@
     "2. **Bold**: Surround your text with '\\__' or '\\**'\n",
     "3. `inline`: Surround your text with '\\`'\n",
     "4.  > blockquote: Place '\\>' before your text.\n",
-    "5.  [Links](http://course-v3.fast.ai/): Surround the text you want to link with '\\[\\]' and place the link adjacent to the text, surrounded with '()'\n"
+    "5.  [Links](http://course.fast.ai/): Surround the text you want to link with '\\[\\]' and place the link adjacent to the text, surrounded with '()'\n"
    ]
   },
   {

--- a/nbs/dl1/lesson3-planet.ipynb
+++ b/nbs/dl1/lesson3-planet.ipynb
@@ -40,7 +40,7 @@
    "source": [
     "The planet dataset isn't available on the [fastai dataset page](https://course.fast.ai/datasets) due to copyright restrictions. You can download it from Kaggle however. Let's see how to do this by using the [Kaggle API](https://github.com/Kaggle/kaggle-api) as it's going to be pretty useful to you if you want to join a competition or use other Kaggle datasets later on.\n",
     "\n",
-    "First, install the Kaggle API by uncommenting the following line and executing it, or by executing it in your terminal (depending on your platform you may need to modify this slightly to either add `source activate fastai` or similar, or prefix `pip` with a path. Have a look at how `conda install` is called for your platform in the appropriate *Returning to work* section of https://course-v3.fast.ai/. (Depending on your environment, you may also need to append \"--user\" to the command.)"
+    "First, install the Kaggle API by uncommenting the following line and executing it, or by executing it in your terminal (depending on your platform you may need to modify this slightly to either add `source activate fastai` or similar, or prefix `pip` with a path. Have a look at how `conda install` is called for your platform in the appropriate *Returning to work* section of https://course.fast.ai/. (Depending on your environment, you may also need to append \"--user\" to the command.)"
    ]
   },
   {


### PR DESCRIPTION
* Also switch all `http://course.fast.ai` links to `https://course.fast.ai`.