### PR TITLE
Revert "fixed broken img link (#157)"

### DIFF
--- a/docs/gpu_tutorial.md
+++ b/docs/gpu_tutorial.md
@@ -21,8 +21,8 @@ It so happens that Deep Learning also requires super fast matrix computations. S
 
 Deep Learning really only cares about the number of Floating Point Operations (FLOPs) per second. GPUs are highly optimized for that. 
 
-<img alt="gpu_cpu_comparison" src="/docs/images/gpu/gpu_cpu_comparison.png" class="screenshot">
-      
+<img alt="gpu_cpu_comparison" src="/images/gpu/gpu_cpu_comparison.png" class="screenshot">
+
 In the chart above, you can see that GPUs (red/green) can theoretically do 10-15x the operations of CPUs (in blue).  This speedup very much applies in practice too. **But do not take our word for it!**  
 
 Try running this inside a Jupyter Notebook:


### PR DESCRIPTION
This reverts commit 8ecaedbecb2d5476f0743e6854e78e8d88a5abf5.

/images should be the correct location. Consistent with other tutorials
https://course.fast.ai/gpu_tutorial.html