### PR TITLE
Removed 're.compile' from lesson #1 since not redundant with 'from_name_re'

### DIFF
--- a/nbs/dl1/lesson1-pets.ipynb
+++ b/nbs/dl1/lesson1-pets.ipynb
@@ -192,7 +192,7 @@
    "outputs": [],
    "source": [
     "np.random.seed(2)\n",
-    "pat = re.compile(r'/([^/]+)_\\d+.jpg$')"
+    "pat = r'/([^/]+)_\\d+.jpg$'"
    ]
   },
   {


### PR DESCRIPTION
Fix for issue #163.

Minor change.  Only removed re.compile.  Did simple manual verification on my end.