### PR TITLE
Add missing imports from lesson 1

### DIFF
--- a/nbs/dl1/lesson1-pets.ipynb
+++ b/nbs/dl1/lesson1-pets.ipynb
@@ -43,6 +43,7 @@
    "outputs": [],
    "source": [
     "from fastai.vision import *\n",
+    "from fastai.datasets import untar_data\n",
     "from fastai.metrics import error_rate"
    ]
   },

--- a/nbs/dl1/lesson1-pets.ipynb
+++ b/nbs/dl1/lesson1-pets.ipynb
@@ -43,7 +43,7 @@
    "outputs": [],
    "source": [
     "from fastai.vision import *\n",
-    "from fastai.datasets import untar_data\n",
+    "from fastai.datasets import untar_data, URLs\n",
     "from fastai.metrics import error_rate"
    ]
   },

--- a/nbs/dl1/lesson1-pets.ipynb
+++ b/nbs/dl1/lesson1-pets.ipynb
@@ -44,7 +44,8 @@
    "source": [
     "from fastai.vision import *\n",
     "from fastai.datasets import untar_data, URLs\n",
-    "from fastai.metrics import error_rate"
+    "from fastai.metrics import error_rate\n",
+    "import numpy as np"
    ]
   },
   {


### PR DESCRIPTION
I was not able to get past `learn = create_cnn(data, models.resnet34, metrics=error_rate)` because the kernel died.
This is a known issue https://forums.fast.ai/t/platform-aws-ec2-dlami/27340/19