### PR TITLE
Adding ImageCleaner 'path' argument

### DIFF
--- a/nbs/dl1/lesson2-download.ipynb
+++ b/nbs/dl1/lesson2-download.ipynb
@@ -832,7 +832,7 @@
     }
    ],
    "source": [
-    "ImageCleaner(ds, idxs)"
+    "ImageCleaner(ds, idxs, path)"
    ]
   },
   {


### PR DESCRIPTION
ImageCleaner class requires a 'path' argument as per the [docs ](https://docs.fast.ai/widgets.image_cleaner.html#ImageCleaner)