### PR TITLE
ImageCleaner: added missing required  argument

### DIFF
--- a/nbs/dl1/lesson2-download.ipynb
+++ b/nbs/dl1/lesson2-download.ipynb
@@ -832,7 +832,7 @@
     }
    ],
    "source": [
-    "ImageCleaner(ds, idxs)"
+    "ImageCleaner(ds, idxs, path)"
    ]
   },
   {
@@ -953,7 +953,7 @@
     }
    ],
    "source": [
-    "ImageCleaner(ds, idxs, duplicates=True)"
+    "ImageCleaner(ds, idxs, path, duplicates=True)"
    ]
   },
   {


### PR DESCRIPTION
Mandatory 3rd argument `path` added to calls of `ImageCleaner`.