### PR TITLE
Install correct pytorch/cudatoolkit versions on sagemaker

### DIFF
--- a/docs/setup/sagemaker-create
+++ b/docs/setup/sagemaker-create
@@ -10,6 +10,7 @@ mkdir /home/ec2-user/SageMaker/.fastai && ln -s /home/ec2-user/SageMaker/.fastai
 # install the fastai library and dependencies
 echo "Install the fastai library and dependencies in new conda enviornment"
 cd /home/ec2-user/SageMaker
+# for explanations of the -mqyp flags, check `conda create --help`
 conda create -mqyp envs/fastai -c pytorch -c fastai fastai ipykernel
 echo "Finished installing environment"
 
@@ -37,12 +38,20 @@ chmod u+x custom-start-script.sh
 
 # install a standard start script which is run each time the instance is started
 echo "Install the standard start script"
-cat > /home/ec2-user/SageMaker/.fastai/std-start-script.sh <<EOF
+cat > /home/ec2-user/SageMaker/.fastai/std-start-script.sh <<\EOF
 #!/bin/bash
 # install the ipython kernel
 echo "Install the ipython fastai kernel"
 cd /home/ec2-user/SageMaker
 source activate envs/fastai
+
+cuda_version=$(nvcc --version | awk 'match($0, /Cuda compilation tools, release [0-9]+\.[0-9]+/) { print substr($0, RSTART+32, RLENGTH-(RSTART+31))}')
+echo "Found Cuda version $cuda_version"
+# Install pytorch with correct cuda version
+# This command comes from the "Quick Start Locally" tool at https://pytorch.org/ as of 12 February, 2019
+# With selections Stable (1.0) / Linux / Conda / Python 3.6 / CUDA 9.0
+conda install -y pytorch torchvision cudatoolkit=${cuda_version} -c pytorch
+
 python -m ipykernel install --name 'fastai' --display-name 'Python 3' --user
 echo "Install jupyter nbextension"
 source /home/ec2-user/anaconda3/bin/activate JupyterSystemEnv


### PR DESCRIPTION
This change updates the `sagemaker-create` script to check the Cuda version and install the appropriate cudatoolkit and pytorch versions using conda.

Before this change, it took about 40 minutes to run the first `learn.fit_one_cycle(4)` call in lesson 1 of the 2019 deep-learning 1 course on my Sagemaker instance. After this change, it took 1m50s.

Before this change:
![image](https://user-images.githubusercontent.com/1049620/52679051-9fcfd900-2ee8-11e9-9145-ef9baccca1d7.png)

After this change:
![image](https://user-images.githubusercontent.com/1049620/52679140-f0473680-2ee8-11e9-8e5d-505e3f3dba74.png)


If you check the installed/active Cuda version using a Terminal, you find:

```bash
sh-4.2$ nvcc --version
nvcc: NVIDIA (R) Cuda compiler driver
Copyright (c) 2005-2017 NVIDIA Corporation
Built on Fri_Sep__1_21:08:03_CDT_2017
Cuda compilation tools, release 9.0, V9.0.176
```


One thing I would ask of a reviewer - I wrote a bit of awk script to extract the active Cuda version and ask conda to use that version for cudatoolkit. I'm new to all these tools and I have no idea if that is super-brittle and there might be a better way to find and select the correct version.