### PR TITLE
fixed name tensor not defined

### DIFF
--- a/nbs/dl1/lesson2-sgd.ipynb
+++ b/nbs/dl1/lesson2-sgd.ipynb
@@ -83,7 +83,7 @@
     }
    ],
    "source": [
-    "a = tensor(3.,2); a"
+    "a = torch.tensor([3.,2]); a"
    ]
   },
   {
@@ -146,7 +146,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "a = tensor(-1.,1)"
+    "a = torch.tensor([-1.,1])"
    ]
   },
   {
@@ -18659,8 +18659,20 @@
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.1"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 2
 }


### PR DESCRIPTION
Google collab throws an error tensor not defined. From docs: https://pytorch.org/docs/stable/tensors.html

```
>>> torch.tensor([[1., -1.], [1., -1.]])
tensor([[ 1.0000, -1.0000],
        [ 1.0000, -1.0000]])
```