### PR TITLE
Update regular expression to work with Windows style paths

### DIFF
--- a/nbs/dl1/lesson1-pets.ipynb
+++ b/nbs/dl1/lesson1-pets.ipynb
@@ -192,7 +192,7 @@
    "outputs": [],
    "source": [
     "np.random.seed(2)\n",
-    "pat = r'/([^/]+)_\\d+.jpg$'"
+    "pat = r'[/\\\\]([^/\\\\]+)_\\d+.jpg$'"
    ]
   },
   {


### PR DESCRIPTION
Makes the regular expression work with both POSIX and Windows style paths.

Conversion of path to string in Windows generates a string with DOS style backslashes. The original regular expression failed to match the string resulting in the failure of subsequent lines of code. The new regular expression works with forward slashes as well as backslashes.