### PR TITLE
Fix for datetime type error in rossman-data-clean

### DIFF
--- a/nbs/dl1/lesson3-imdb.ipynb
+++ b/nbs/dl1/lesson3-imdb.ipynb
@@ -1279,31 +1279,6 @@
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.5"
-  },
-  "toc": {
-   "base_numbering": 1,
-   "nav_menu": {},
-   "number_sections": false,
-   "sideBar": true,
-   "skip_h1_title": false,
-   "title_cell": "Table of Contents",
-   "title_sidebar": "Contents",
-   "toc_cell": false,
-   "toc_position": {},
-   "toc_section_display": true,
-   "toc_window_display": false
   }
  },
  "nbformat": 4,

--- a/nbs/dl1/lesson3-imdb.ipynb
+++ b/nbs/dl1/lesson3-imdb.ipynb
@@ -225,7 +225,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data = TextDataBunch.load(path)"
+    "data = load_data(path)"
    ]
   },
   {
@@ -551,7 +551,7 @@
     "            .label_for_lm()           \n",
     "           #We want to do a language model so we label accordingly\n",
     "            .databunch(bs=bs))\n",
-    "data_lm.save('tmp_lm')"
+    "data_lm.save('data_lm.pkl')"
    ]
   },
   {
@@ -569,7 +569,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data_lm = TextLMDataBunch.load(path, 'tmp_lm', bs=bs)"
+    "data_lm = load_data(path, 'data_lm.pkl', bs=bs)"
    ]
   },
   {
@@ -950,7 +950,7 @@
     "             #label them all with their folders\n",
     "             .databunch(bs=bs))\n",
     "\n",
-    "data_clas.save('tmp_clas')"
+    "data_clas.save('data_clas.pkl')"
    ]
   },
   {
@@ -959,7 +959,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data_clas = TextClasDataBunch.load(path, 'tmp_clas', bs=bs)"
+    "data_clas = load_data(path, 'data_clas.pkl', bs=bs)"
    ]
   },
   {
@@ -1279,6 +1279,31 @@
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.5"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": false,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
   }
  },
  "nbformat": 4,

--- a/nbs/dl1/lesson4-collab-Copy1.ipynb
+++ b/nbs/dl1/lesson4-collab-Copy1.ipynb
@@ -1,0 +1,1268 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from fastai.collab import *\n",
+    "from fastai.tabular import *"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Collaborative filtering example"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`collab` models use data in a `DataFrame` of user, items, and ratings."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "user,item,title = 'userId','movieId','title'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "PosixPath('/home/ubuntu/.fastai/data/movie_lens_sample')"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "path = untar_data(URLs.ML_SAMPLE)\n",
+    "path"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>userId</th>\n",
+       "      <th>movieId</th>\n",
+       "      <th>rating</th>\n",
+       "      <th>timestamp</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>73</td>\n",
+       "      <td>1097</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>1255504951</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>561</td>\n",
+       "      <td>924</td>\n",
+       "      <td>3.5</td>\n",
+       "      <td>1172695223</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>157</td>\n",
+       "      <td>260</td>\n",
+       "      <td>3.5</td>\n",
+       "      <td>1291598691</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>358</td>\n",
+       "      <td>1210</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>957481884</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>130</td>\n",
+       "      <td>316</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>1138999234</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   userId  movieId  rating   timestamp\n",
+       "0      73     1097     4.0  1255504951\n",
+       "1     561      924     3.5  1172695223\n",
+       "2     157      260     3.5  1291598691\n",
+       "3     358     1210     5.0   957481884\n",
+       "4     130      316     2.0  1138999234"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ratings = pd.read_csv(path/'ratings.csv')\n",
+    "ratings.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "That's all we need to create and train a model:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data = CollabDataBunch.from_df(ratings, seed=42)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "y_range = [0,5.5]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "learn = collab_learner(data, n_factors=50, y_range=y_range)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "Total time: 00:03 <p><table style='width:300px; margin-bottom:10px'>\n",
+       "  <tr>\n",
+       "    <th>epoch</th>\n",
+       "    <th>train_loss</th>\n",
+       "    <th>valid_loss</th>\n",
+       "  </tr>\n",
+       "  <tr>\n",
+       "    <th>1</th>\n",
+       "    <th>1.629454</th>\n",
+       "    <th>0.982241</th>\n",
+       "  </tr>\n",
+       "  <tr>\n",
+       "    <th>2</th>\n",
+       "    <th>0.856353</th>\n",
+       "    <th>0.678751</th>\n",
+       "  </tr>\n",
+       "  <tr>\n",
+       "    <th>3</th>\n",
+       "    <th>0.655987</th>\n",
+       "    <th>0.669647</th>\n",
+       "  </tr>\n",
+       "</table>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "learn.fit_one_cycle(3, 5e-3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Movielens 100k"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's try with the full Movielens 100k data dataset, available from http://files.grouplens.org/datasets/movielens/ml-100k.zip"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "path=Config.data_path()/'ml-100k'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>userId</th>\n",
+       "      <th>movieId</th>\n",
+       "      <th>rating</th>\n",
+       "      <th>timestamp</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>196</td>\n",
+       "      <td>242</td>\n",
+       "      <td>3</td>\n",
+       "      <td>881250949</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>186</td>\n",
+       "      <td>302</td>\n",
+       "      <td>3</td>\n",
+       "      <td>891717742</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>22</td>\n",
+       "      <td>377</td>\n",
+       "      <td>1</td>\n",
+       "      <td>878887116</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>244</td>\n",
+       "      <td>51</td>\n",
+       "      <td>2</td>\n",
+       "      <td>880606923</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>166</td>\n",
+       "      <td>346</td>\n",
+       "      <td>1</td>\n",
+       "      <td>886397596</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   userId  movieId  rating  timestamp\n",
+       "0     196      242       3  881250949\n",
+       "1     186      302       3  891717742\n",
+       "2      22      377       1  878887116\n",
+       "3     244       51       2  880606923\n",
+       "4     166      346       1  886397596"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ratings = pd.read_csv(path/'u.data', delimiter='\\t', header=None,\n",
+    "                      names=[user,item,'rating','timestamp'])\n",
+    "ratings.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>movieId</th>\n",
+       "      <th>title</th>\n",
+       "      <th>date</th>\n",
+       "      <th>N</th>\n",
+       "      <th>url</th>\n",
+       "      <th>g0</th>\n",
+       "      <th>g1</th>\n",
+       "      <th>g2</th>\n",
+       "      <th>g3</th>\n",
+       "      <th>g4</th>\n",
+       "      <th>...</th>\n",
+       "      <th>g9</th>\n",
+       "      <th>g10</th>\n",
+       "      <th>g11</th>\n",
+       "      <th>g12</th>\n",
+       "      <th>g13</th>\n",
+       "      <th>g14</th>\n",
+       "      <th>g15</th>\n",
+       "      <th>g16</th>\n",
+       "      <th>g17</th>\n",
+       "      <th>g18</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1</td>\n",
+       "      <td>Toy Story (1995)</td>\n",
+       "      <td>01-Jan-1995</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>http://us.imdb.com/M/title-exact?Toy%20Story%2...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2</td>\n",
+       "      <td>GoldenEye (1995)</td>\n",
+       "      <td>01-Jan-1995</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>http://us.imdb.com/M/title-exact?GoldenEye%20(...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>3</td>\n",
+       "      <td>Four Rooms (1995)</td>\n",
+       "      <td>01-Jan-1995</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>http://us.imdb.com/M/title-exact?Four%20Rooms%...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>4</td>\n",
+       "      <td>Get Shorty (1995)</td>\n",
+       "      <td>01-Jan-1995</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>http://us.imdb.com/M/title-exact?Get%20Shorty%...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>5</td>\n",
+       "      <td>Copycat (1995)</td>\n",
+       "      <td>01-Jan-1995</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>http://us.imdb.com/M/title-exact?Copycat%20(1995)</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>5 rows × 24 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   movieId              title         date   N  \\\n",
+       "0        1   Toy Story (1995)  01-Jan-1995 NaN   \n",
+       "1        2   GoldenEye (1995)  01-Jan-1995 NaN   \n",
+       "2        3  Four Rooms (1995)  01-Jan-1995 NaN   \n",
+       "3        4  Get Shorty (1995)  01-Jan-1995 NaN   \n",
+       "4        5     Copycat (1995)  01-Jan-1995 NaN   \n",
+       "\n",
+       "                                                 url  g0  g1  g2  g3  g4 ...   \\\n",
+       "0  http://us.imdb.com/M/title-exact?Toy%20Story%2...   0   0   0   1   1 ...    \n",
+       "1  http://us.imdb.com/M/title-exact?GoldenEye%20(...   0   1   1   0   0 ...    \n",
+       "2  http://us.imdb.com/M/title-exact?Four%20Rooms%...   0   0   0   0   0 ...    \n",
+       "3  http://us.imdb.com/M/title-exact?Get%20Shorty%...   0   1   0   0   0 ...    \n",
+       "4  http://us.imdb.com/M/title-exact?Copycat%20(1995)   0   0   0   0   0 ...    \n",
+       "\n",
+       "   g9  g10  g11  g12  g13  g14  g15  g16  g17  g18  \n",
+       "0   0    0    0    0    0    0    0    0    0    0  \n",
+       "1   0    0    0    0    0    0    0    1    0    0  \n",
+       "2   0    0    0    0    0    0    0    1    0    0  \n",
+       "3   0    0    0    0    0    0    0    0    0    0  \n",
+       "4   0    0    0    0    0    0    0    1    0    0  \n",
+       "\n",
+       "[5 rows x 24 columns]"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "movies = pd.read_csv(path/'u.item',  delimiter='|', encoding='latin-1', header=None,\n",
+    "                    names=[item, 'title', 'date', 'N', 'url', *[f'g{i}' for i in range(19)]])\n",
+    "movies.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "100000"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(ratings)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>userId</th>\n",
+       "      <th>movieId</th>\n",
+       "      <th>rating</th>\n",
+       "      <th>timestamp</th>\n",
+       "      <th>title</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>196</td>\n",
+       "      <td>242</td>\n",
+       "      <td>3</td>\n",
+       "      <td>881250949</td>\n",
+       "      <td>Kolya (1996)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>63</td>\n",
+       "      <td>242</td>\n",
+       "      <td>3</td>\n",
+       "      <td>875747190</td>\n",
+       "      <td>Kolya (1996)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>226</td>\n",
+       "      <td>242</td>\n",
+       "      <td>5</td>\n",
+       "      <td>883888671</td>\n",
+       "      <td>Kolya (1996)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>154</td>\n",
+       "      <td>242</td>\n",
+       "      <td>3</td>\n",
+       "      <td>879138235</td>\n",
+       "      <td>Kolya (1996)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>306</td>\n",
+       "      <td>242</td>\n",
+       "      <td>5</td>\n",
+       "      <td>876503793</td>\n",
+       "      <td>Kolya (1996)</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   userId  movieId  rating  timestamp         title\n",
+       "0     196      242       3  881250949  Kolya (1996)\n",
+       "1      63      242       3  875747190  Kolya (1996)\n",
+       "2     226      242       5  883888671  Kolya (1996)\n",
+       "3     154      242       3  879138235  Kolya (1996)\n",
+       "4     306      242       5  876503793  Kolya (1996)"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rating_movie = ratings.merge(movies[[item, title]])\n",
+    "rating_movie.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data = CollabDataBunch.from_df(rating_movie, seed=42, pct_val=0.1, item_name=title)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table>  <col width='10%'>  <col width='10%'>  <col width='10%'>  <tr>\n",
+       "    <th>userId</th>\n",
+       "    <th>title</th>\n",
+       "    <th>target</th>\n",
+       "  </tr>\n",
+       "  <tr>\n",
+       "    <th>126</th>\n",
+       "    <th>Event Horizon (1997)</th>\n",
+       "    <th>1.0</th>\n",
+       "  </tr>\n",
+       "  <tr>\n",
+       "    <th>44</th>\n",
+       "    <th>Young Frankenstein (1974)</th>\n",
+       "    <th>4.0</th>\n",
+       "  </tr>\n",
+       "  <tr>\n",
+       "    <th>718</th>\n",
+       "    <th>Star Trek: First Contact (1996)</th>\n",
+       "    <th>4.0</th>\n",
+       "  </tr>\n",
+       "  <tr>\n",
+       "    <th>506</th>\n",
+       "    <th>Magnificent Seven, The (1954)</th>\n",
+       "    <th>5.0</th>\n",
+       "  </tr>\n",
+       "  <tr>\n",
+       "    <th>373</th>\n",
+       "    <th>Good, The Bad and The Ugly, The (1966)</th>\n",
+       "    <th>3.0</th>\n",
+       "  </tr>\n",
+       "</table>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "data.show_batch()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "y_range = [0,5.5]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "learn = collab_learner(data, n_factors=40, y_range=y_range, wd=1e-1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "LR Finder is complete, type {learner_name}.recorder.plot() to see the graph.\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZ4AAAEKCAYAAAAiizNaAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4wLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvqOYd8AAAIABJREFUeJzt3Xl8VNX5+PHPk51sZA8hAcK+QyJhcUdxXyjYulCtilqrP+vSxVpbaxf1q19btbW29UtV1LoWFfcdRVxACBD2PUEICSRhTyBke35/zA0MMEmGZCYzCc/79ZoXM+eee+9zGMiTe+6554iqYowxxrSXkEAHYIwx5vhiiccYY0y7ssRjjDGmXVniMcYY064s8RhjjGlXlniMMca0K0s8xhhj2pUlHmOMMe3Kb4lHRJ4RkTIRWd7E9kQRmSkiS0VkvogMc8oHikiB22uPiNzhbPuDiGxx23aBv+I3xhjjH+KvmQtE5DSgEnheVYd52P5noFJV/ygig4B/qOqEI+qEAluAsar6nYj8wdnnL8cSS0pKimZnZ7eyJcYYc3xauHBhhaqm+vq4Yb4+YCNVnSMi2c1UGQI86NRdLSLZIpKuqtvc6kwANqjqd22JJTs7m/z8/LYcwhhjjjsi0qafvU0J5D2eJcAlACIyBugFZB1R5wrg5SPKfup0zz0jIolNHVxEbhSRfBHJLy8v92Xcxhhj2iCQiechIFFECoBbgcVAXeNGEYkAJgIz3Pb5F9AXyAFKgUeaOriqTlPVPFXNS031+ZWiMcaYVvJbV1tLVHUPMBVARAQocl6NzgcWuXe9ub8XkX8D77ZPtMYYY3wlYFc8IpLgXNUA3ADMcZJRoykc0c0mIhluHycDHkfMGWOMCV5+u+IRkZeB8UCKiBQDvwfCAVT1SWAw8LyI1AMrgevd9o0GzgZ+csRhHxaRHECBjR62G2OMCXL+HNU2pYXtc4H+TWzbByR7KP+Rb6IzxhgTKDZzgTHGmHZliceH6uobeHn+JmrrGwIdijHGBC1LPD705foK7n5jGR8s3xroUIwxJmhZ4vGhwvIqAOYVbg9wJMYYE7ws8fhQUUUlYInHGGOaY4nHh4oqXFc8heVVbNtTHeBojDEmOFni8aGi8ir6p8UCdtVjjDFNscTjI/tr6inZXc2FIzKIiwxjXuGOQIdkjDFByRKPj2zc7upm65cWy5jeSXxrVzzGGOORJR4faby/0zslhnF9kimssPs8xhjjiSUeH2lMPNnJMZzY1zXbj93nMcaYo1ni8ZHC8iq6xUcRExnG4Ix44qLCLPEYY4wHlnh8pKiikt4pMQCEhghjeycxd4MlHmOMOZIlHh8pqqiid2rMwc/j+iSzcfs+SnfvD2BUxhgTfCzx+MDOqhp27qulT8rhiQfgWxtWbYwxh7HE4wNF2w+NaGs0OCOeeLvPY4wxR7HE4wNF5UcnntAQYUzvZOZa4jHGmMP4LfGIyDMiUiYiy5vYnigiM0VkqYjMF5Fhbts2isgyESkQkXy38iQR+URE1jl/Jvor/mNRVFFFaIjQIyn6sPIT+ybz3fZ9lOyy+zzGGNPIn1c8zwLnNbP9N0CBqo4Argb+dsT2M1Q1R1Xz3Mp+DcxS1f7ALOdzwBVVVNEzKZrw0MP/Ok9ynud5+MPVHKirD0RoxhgTdPyWeFR1DtDcnfUhuJIHqroayBaR9BYO+z3gOef9c8CktsbpC4UVVYd1szUanBHPHWf1582CEqZMm0fZXpvJwBhjAnmPZwlwCYCIjAF6AVnONgU+FpGFInKj2z7pqloK4PyZ1o7xetTQoGxsIvEA3HHWAP555QmsKt3LxL9/zdLiXe0coTHGBJdAJp6HgEQRKQBuBRYDdc62k1X1BOB84BYROe1YDy4iN4pIvojkl5eX+yzoI23bW83+2vomEw/ABcMzeP3mkwgNES59cq6NdDPGHNcClnhUdY+qTlXVHFz3eFKBImdbifNnGTATGOPstk1EMgCcP8uaOf40Vc1T1bzU1FS/taNxRFufZhIPwJDu8bz905OJjghlRn6x3+IxxphgF7DEIyIJIhLhfLwBmKOqe0QkRkTinDoxwDlA48i4t4FrnPfXAG+1Z8yeND7Dk91C4gFIjo1kdHYS+d/ZQ6XGmONXmL8OLCIvA+OBFBEpBn4PhAOo6pPAYOB5EakHVgLXO7umAzNFpDG+l1T1Q2fbQ8B/ReR6YBNwqb/i91ZReRVR4SF0i4/yqv7o7CQ+XrmNsj3VpHm5jzHGdCZ+SzyqOqWF7XOB/h7KC4GRTeyzHZjgkwB9pKiiiuzkGEJCxKv6o3snAZD/3U4uGJ7hz9CMMSYo2cwFbVRUUUWf1Ja72RoN7R5PVHgICzZad5sx5vhkiacNausb2LRjX7Mj2o4UHhpCbo9ESzzGmOOWJZ42KN65n7oGpXdK7DHtNzo7kZUle6g8UNdyZWOM6WQs8bRBYXklwDFd8YDrPk+DwuJNO/0RljHGBDVLPG2wYONOwkKEgd3ijmm/3J6JhIhrf2OMOd74bVTb8WDO2nJG9UokNvLY/hpjI8MY0j2eBUXtc5+neOc+auoaiI0MIyYyjOiIUJzh6sYY0+4s8bRS2d5qVpbu4c5zB7Zq/7xeSbyyYBO19Q1HzWrtS+8vK+WWlxaheqgsKjyEx6/I5Zyh3fx2XmOMaYp1tbXSl2srADh9QOum4xmdnUR1bQMrSvb4MqzD7Kyq4d63ljO0ezx/vTyH+ycN49fnDyIrMZo/vL2C/TVHL9VQV9/AzS8s5D9zN/otLmPM8c2ueFppzrpyUmIjGJIR36r9R2e71rDL37iDnB4JvgztoAfeX8WufbU8f91YhnQ/FGdOjwSumDaPf39ZyG0TDn+Gd9qXhXywfCtLNu/iyrG9vH4w1hhjvGVXPK3Q0KB8ua6CU/untvoHc1p8FL2So/32PM+X68p5bWExPzm9z2FJB2Bcn2TOH9aNf83ewNbdh9YIWrN1L3/9ZB2ZCV0o2V1tzxoZY/zCEk8rLC/ZzY6qGk4bkNKm4+T1SiJ/407U/QaMD+yrqePuN5bRJzWGW888alYiAO4+fzD1DcrDH60GXA/D/nLGEuKiwnjlxnFER4TyZsEWn8ZljDFgiadV5qx1re9zav+2LbcwOjuR7VU1FFZU+SKsgx75eC3FO/fz0CUjiAoP9VinZ3I0153SmzcWbWHJ5l08OXsDy7bs5v5Jw+iRFM05Q9J5b2mpLdltjPE5SzytMGdtBcMy40mJjWzTcQ5OGOrDLq1Fm3Yy/esirhzbkzHO8Ztyyxl9SYmN4JczlvD4Z+uYOLI75zsTl07KzWRPdR2z1/hvET1jzPHJEs8x2lNdy8JNOzmtjVc74Fo8LiU2grkbvF+R9PWFxVz9zHz2VNcetW33/lpue3kxGV27cNf5g1o8VlxUOL88ZyDryipJiI7gjxOHHtx2Sr8UUmIjeMu624wxPmaJ5xh9s3479Q3Kaa0cRu1ORDhtQCqz15ZT39DyfR5V5YnP1zNnbTk3v7CQmrqGw7b9ZuYySndX8/iUXOKjwr2K4dK8Hvz41N7844cnkBgTcbA8LDSEi0Z059NVZR6TnDHGtJYlnmM0Z105sZFhnNAz0SfHmzAonV37ar2at23Zlt0UVVRxxsBUvl6/nd/MXHZwYMKrCzbz3tJSfnHOAEb18j620BDhtxcO8dgtNyk3k5q6Bj5cttX7BhljTAss8RwDVeWLNeWc2DeZiDDf/NWdOiCFsBBh1uqyFuu+ubiEiNAQ/np5Lnec1Z/XFhbz98/Ws27bXv7wzgpO6ZfCTaf19UlcACOzupKdHG2j24wxPuW3xCMiz4hImYgsb2J7oojMFJGlIjJfRIY55T1E5HMRWSUiK0Tkdrd9/iAiW0SkwHld4K/4PSmsqGLLrv0+6WZrFB8VzpjeSXy2qvnEU9+gvLO0hPEDU+kaHc7tE/pzyQmZPPrJWq56+ltiIsJ49LKRPn3gU0T4Xk4mcwu3H/a8jzHGtIU/r3ieBc5rZvtvgAJVHQFcDfzNKa8DfqGqg4FxwC0iMsRtv8dUNcd5ve+HuJvUOIz6dB8MLHB35qA01mzby+Yd+5qsM3fDdsr3HuB7OZmAKyk8dMkITuqbzLY9B3jkspGkxUf5NC5wdbepwttL7KrHGOMbfks8qjoHaG6c8BBgllN3NZAtIumqWqqqi5zyvcAqINNfcR6L2WvK6ZMSQ8/kaJ8ed8LgdAA+a6a77c2CLcRGhjFhcNrBsoiwEJ65djQf3H4q4wemNblvW/ROiSGnRwKvLthMgxcDIIwxpiWBvMezBLgEQETGAL2ALPcKIpIN5ALfuhX/1Omee0ZEfHOH3wvVtfXMK9zO6QN9e7UDrh/ufVJimrzPU11bz4fLt3Lu0G5HPRAaFR7K4FbOF+etqSdns6G8is/XtHwfyhhjWhLIxPMQkCgiBcCtwGJc3WwAiEgs8Dpwh6o2TuH8L6AvkAOUAo80dXARuVFE8kUkv7y87Q9Bzi3czoG6Br9dWUwYnMa8Ddup8rAc9mery6g8UMek3O5+OXdLLhieQfeuUUybUxiQ8xtjOpeAJR5V3aOqU1U1B9c9nlSgCEBEwnElnRdV9Q23fbapar2qNgD/BsY0c/xpqpqnqnmpqW2/SvliTTlR4SGMbWE2gNY6c1A6NfUNfLW+4qhtbxVsISU2kpP6tm1uuNYKDw3hulN6823RDpYW7wpIDMaYziNgiUdEEkSk8YnFG4A5qrpHXEtjPg2sUtVHj9gnw+3jZMDjiDl/mL2mjBP7JDc591lb5WUnEhcVdtTott37avl8dTkXj8wgNIBLFFw+ugdxkWH8+8uigMVgjOkc/Dmc+mVgLjBQRIpF5HoRuUlEbnKqDAZWiMhq4Hygcdj0ycCPgDM9DJt+WESWichS4AzgZ/6K393Giio2bt/nt242cF1VnD4glc/WlB12E/+9ZaXU1DcwKSew4yviosL54dievL+stNnRd8YY0xK/LQSnqlNa2D4XOGrOflX9CvD4q72q/sg30R2b2c5N9dauNuqtCYPTeHdpKctLdlPXoDz1ZSEfLt/KgPRYRmR19eu5vXHtydk8/VUR07/eyL0XD2l5B2OM8cBWIPXC7LXlZCdHk50S49fznD4gjRCBqdMXsL2qhrioMG48rS/XnZKNqwcysDK6duHikd15ZcEmbp/Qn67R3s0HZ4wx7mzKnBZU19Yzd8N2v3azNUqKieDMQelER4Zy70VDmHv3BH59/iDS4nz/YGhr3XBqb/bV1PPS/E2BDsV4MGvVNlaU7A50GMY0y654WjDPGUbtj+d3PHnqmrx2OU9rDe3elRP7JDMjfzM3j/fdvHCmbfbX1PO7t5bz2sJiMrpGMesXpxMdYf+9TXCyK54WfLG2nMiwEE7skxzoUILGKf1TKKyosuUSgsT6skom/eNrXl9UzPdPyKJ0dzX//HxDoMMypkmWeFrwxZpyxvlxGHVHNCzTNdBh+Rbr0mlObX0D1bWtXzp8f009078uYte+mibrvL2khIlPfEVF5QGemzqGRy4byaSc7kybU8h32327pLoxvmKJpxmbtu+jsKKK8e3UzdZRDHcSz7JiSzzN+f3bKxj34KxWLW1eV9/AT19axB/fWcmvXlt6cN0ldwu/28EdryxmaPd43rvt1IOzpv/6/MGEhQr3v7eqzW0wxh8s8TRj9lrXMOr2GFjQkSTFRJCZ0IVldsXTpOraet4uKGHXvlqufOpbPlzu/WJ6qsrdbyxj1uoyTumXwscrtzFz8eGzg1ceqONnry4hM7EL06eOoVvXQwNQunWN4tYz+/PJym18sbbt00UZ42uWeJqxecc++qTE0NvPw6g7omGZ8dbV1ow5a8upPFDH367IYXBGPDe/uJDn5270at8/f7SGGQuLuW1Cf567bgyjsxP5/dsrKN29/2Cd+95ZSfHOfTx6WQ6xkUcPIrjulGyyk6P54zsrDlsifX9NPftrWt/9Z4wvWOJpxm8vHMIHd5wa6DCC0oisBDZu3+dxgMGsVds457EvjusZDt5bVkpidDgXDs/g5R+PY8KgdO59awUPfrCKuvqGJvd75qsi/jl7A1PG9ORnZ/UnNET4y6UjqavXg11uH63Yyqv5m7np9L6MzvY8d2BkWCj3XjyEwvIqbvxPPj96+ltOfugzBt/7IaMf+JQnv9jAgTpLQCYwLPG0IDLMBhV40twAg9cXFbN2WyU3PJfP3iAa+bZrXw17q2up9/O6QtW19Xy6chvnDcsgLDSELhGhPHnVCVw5tif/90Uhl0+bx6bthyfl3ftq+cPbK/jTuys5d2g6908advCh4V7JMfzmwsF8ua6Cx2et5+43ljG0ezx3nDWg2TjOHJTOhcMzyN+4k937axmdncjPzx7AuD5JPPTBas5+dA4fLi9FVampa2D11j28VbCF6V8XsWbrXo/3lYzxBRvob1pluFvicZ81u7a+gS/XVjAiqysrSvZw+ysF/PvqvIBOcArw9FdF3PfuyoOfI8NCyEzowrSr8+iXFuvTc81eU05VTT0XDj80p21YaAgPTB7OmN5J3DNzORc8/iV/mDiUybmZvLpgM3/+aDW799dy1bie3HPhkKP+vq4a25OPV2zlsU/XEhEWwl8vzyEirOXfG/9x5Qmo6lEzX3y5rpz7313FTS8solt8FBWVB6g7IiH3TIrm7CHpnD0kndHZSQH/Dk3nYYnHtMqhAQZ7Ditf+N1O9h6o4/+N70dF5QHueXM5D76/insuCtzcbt9tr+LhD1dzcr9kzhiYxr6aeqpq6nhl/mbuen0p//3JiT79ofreslKSYiIY1+fobrDv5WQyqlciP391Cb+csYSHP1xN2d4DjMlO4vcThzC0u+c5+USE//3+CK586ltuPK0P/dPjvI7H03RLp/ZP5b3bknllwWa+2VBBn5RYBnSLY2B6HLFRYXyxppxPVm7lP/O+4+mvikiLi+SiEd2ZmNOdkVldg2IKJ9NxWeIxreZpgMHsNeWEhwon90smLiqc9WWVPPVVEf3SYrliTM92j1FVuefN5YSHhvDIpTmHjf4akBbHL2Ys4fm5G5l6cm+fnG9/TT2zVm1jUm4mYaGer0iyEqN5+cZxPPnFBt5ZUsI9Fw3h4hEZLf4w757Qhc9+cbrPfuiHhYZw1bheXDWu11Hbfji2Jz8c25OqA3V8vqaMtwtKeGHedzzzdRHZydE8clkOo3q12wLAppOxezym1YZndqXoiBkMZq8pI69XEnFRrglE77lwMKf2T+GeN5ezobyy3WN8s2ALX66r4FfnDTws6QBcckImpw9I5eEP1/hsIMTsNWXsq6nnouEZzdYLDRFuOaMfH95xGhNHdvc6mbT3lUZMZBgXjejOtKvzWHDPWTz8/REocO30+Taq0bSaJR7TakcOMCjZtZ/VW/dyxqBDD9yGhYbw6GU5hIjwn7nftWt8O6tquO/dVeT2TODKsUf/Vi8i/M8lwwkRuPuNZT65mf7uslJSYiMY46eVagOpa5dwLhvdg5d+PI74qHCufmY+67btDXRYpgOyxGNabfgRiafxYcUzjnjgNjUukgtHZPDawmIqD9S1W3z/8/4q9uyv5cFLhjd5DyczoQu/vmAwX62vYEZ+cZvOt6+mjs9WlXHesG5NdrN1BpkJXXjxhrGEhghXPf3tUSP0jGlJ5/3fYfwuOTbysAEGn68uIzOhi8dRYj86sReVB+qOegLfX+YVbmfGwmJ+fFofBnWLb7bulWN6MqZ3Eve9t5L/zN3IypI9rRpy/fnqcvbX1nPh8O6tjLrjyE6J4YXrx3KgroEfPjWPbXuqAx2S6UBscIFpk8YBBjV1DXy9voJJuZke70Pk9khgeGZXnv9mI1eN7en3exX/XbCZpJgIbjvzqEVujxISIjz8/RFc/cx8fvfWCgDiIsPI7eV67iWnR8JR+1TX1nPvW8sp2LyL2nrXczC79tWQEhvZKbvZPBnYLY7nrxvD9//1DU9/VcRvLhgc6JBMB+HXKx4ReUZEykRkeRPbE0VkpogsFZH5IjLMbdt5IrJGRNaLyK/dynuLyLcisk5EXhWRCH+2wTSvcYDBZ6vLqKqpP6qbrZGI8KMTe7GurJJ5hcc+aeaxmr9xB2N7J9ElwrsHgLNTYvjizvF8+aszeOzykUzM6c6arXuYMm0enztLnzeqPFDHtdPnM2NhMT2Tohme2ZVxfZKZmNOd/5k87Lh63mVEVgJjeicdXB7eGG/4u6vtWeC8Zrb/BihQ1RHA1cDfAEQkFPgHcD4wBJgiIo0Pgvwv8Jiq9gd2Atf7J3TjjcYBBv+cvZ6I0BBO6tf0ukUTR3YnITrc6znLWqtk136Kd+5vcjqZpogIPZKimZybxQOTh/PurafSJzWGG57L5/WFrvs/O6tquPLf81iwcSePXZbDU9eM5vEpuTxy2UgevGQE5wzt5o8mBbXxA9JYu62Skl37W65sDH5OPKo6B2ju19shwCyn7mogW0TSgTHAelUtVNUa4BXge+LqnzkTeM3Z/zlgkr/iNy1rHGCwtHg3Y/skNbvqZVR4KJeP7sHHK7cdNuGlry1wliFoa5dXalwkr9w4jnF9kvjFjCU8+slarpg2j1Vb9/LkVaOYlJvpi3A7vMZlQ2avsZmwjXcCPbhgCXAJgIiMAXoBWUAmsNmtXrFTlgzsUtW6I8qPIiI3iki+iOSXl9t/CH9Jjo2ku/N8jDfLR1w1thcNqrz07Sa/xTS/aAdxkWEMzmh+UIE34qLCeeba0Vw4IoPHZ61j8859TL92NGcPSfdBpJ1Dv7RYMhO6HNUlaUxTAp14HgISRaQAuBVYDNQBnjrJtZnyowtVp6lqnqrmpabaQm7+1Njd5s2CeT2SopkwKI2X52/y2/T884t2cEKvRJ/da4kMC+XvV+Typ+8N5b8/OZGT+6W0vNNxREQYPzCVb9ZXHLYEgzFNCWjiUdU9qjpVVXNw3eNJBYpwXcn0cKuaBZQAFUCCiIQdUW4C6PujsrjkhEz6eLlu0bUn9aaisoYxD3zKz18tYNaqbT6bon9HVQ3ryip9PrIsJES4+sTsg0nWHG78wDSqaupbtdqqOf4ENPGISILbqLQbgDmqugdYAPR3RrBFAFcAb6vr0fLPgR84+1wDvNXecZvDnTu0G49eluP1EOlT+qfw4g1jOW9YNz5dtY3rn8sn7/5P+XiF96t0NsVX93fMsTmpbzIRoSE+6W5TVaprba2gzszfw6lfBuYCA0WkWESuF5GbROQmp8pgYIWIrMY1gu12AOcezk+Bj4BVwH9VdYWzz13Az0VkPa57Pk/7sw3GP07ul8KfLx1J/j1nM/3a0fRKjua2VxazrLht838tKNpBRFgII7LsyqQ9xUSGOcOq23Y/tXT3fn7472858cFZHhcZNJ2DXx8gVdUpLWyfC3h8wk9V3wfe91BeiGvUm+kEIsJCOGNQGkMz45n8j2+44fkFvHXLKUdN6OmtBRt3kNMjwRbwC4DxA1O5/71VFO/cR1Zi9DHv/+HyUu56fRn7a+upqWvgg2WlXD66/Wc0N/4X6MEFxgCQFhfFU9fkUVldx4+fzz848EBVmVe4nVteWsRl/zeXqdPnc8tLi7hzxhI+X314t07VgTqWl+xhzDE+v2N8o7XDqvfV1HH3G0u56YVF9EqO5sPbT6V3Sky7Ta9k2p8lHhM0BmfE8/iUXJaX7Obn/y3g9YXFXPT3r7hi2jy+WV8BQEVlDatK9/Dxym385IWFrC87tNTCok07qW9Qu78TIH1TY8lK7HJMiee77VVM/sc3vLJgMzeP78trN51En9RYJudmMq9wB1vsodROyeZqM0FlwuB0fnvBYO5/bxUfLN9K/7RYHrxkOJNyMg+b/qZsbzXnPDaHX722hBk3nURoiLCgaAchAifYAmUB0Tis+o1FWzhQV99id+eX68r56UuLAXhu6hhOG3BoOP6knEwe/WQtbxVs4f+N7+fXuE37s8Rjgs71p/Qmvks43eKjOLV/isfRcmlxUfxx4lBuf6WAp78q5MbT+vJt0Q6Gdu9KbKT9sw6U8QPSeGHeJl76dhNhIcKKkj2sKt1Dl4hQxvROZmzvJHJ7JvDivE08+MEq+qfFMe3qUfRKPnwofs/kaPJ6JTJz0RZuPr2vLbXdydj/UBN0RITL8nq0WG/iyO68t7SUv3y8llP7p1KweZfHZZxN+zmpXzIRYSH88Z2VACREhzMkI5691XU88dk6HlcIEWhQOG9oNx65bCQxTfyiMCk3k3veXM6Kkj32/FQnY4nHdFgiwv2Th3HOY3O4dvp8DtQ1HPPEoMa3oiPCeP66MVRW1zGkezwZXaMOXq3sra4l/7udzC/aQfeELlw5pichzcwucdGIDP74zgpmLt5iiaeTscRjOjT3LjeA0dl2fyfQxvXxPEN5XFQ4ZwxMa3LpjCMlREdwxsA03l5Swt3nD+rUq7oeb+ybNB3exJHduXBEBrk9E0iOjQx0OMaHLjkhk/K9B/h6w/ZAh2J8yK54TIcnIvz9ilzPs8WaDu2MQWnER4Xx5uItnD7AJvvtLCzxmE6huXsFpuOKDAvlwhHdeWNRMQ2qpMZGkhoXSWZiF84d2o1w637rkCzxGGOC2nUnZ7OhrJLFm3ZRtrea6lrX0gvj+iTxjx+eYN2rHZC4Jnzu3PLy8jQ/Pz/QYRhj2khVqaqp58PlW/ntzGWkxEbyfz8aZaPe/EREFqpqnq+Pa9epxpgOQ0SIjQzjB6OyeO2mk1BVfvDkN7xVYPO6dSReJR4R6Ssikc778SJym4gk+Dc0Y4xp2vCsrrx96ymMyEzg9lcKjpo01gQvb694XgfqRaQfrvVvegMv+S0qY4zxQkpsJC/cMJaU2AheX1Qc6HCMl7xNPA3O4myTgb+q6s+ADP+FZYwx3okIC+Hcod34bHWZrVzaQXibeGpFZAqupabfdcrC/ROSMcYcm/OHZbCvpp4v1rZtBVTTPrxNPFOBE4EHVLVIRHoDLzS3g4g8IyJlIrK8ie1dReQdEVkiIitEZKpTfoaIFLi9qkVkkrPtWREpctuW431TjTGd1dg+SSRGh/PBstJAh2K84NVzPKq6ErgNQEQSgThVfaiF3Z4FngAbD33KAAAbjUlEQVSeb2L7LcBKVb1YRFKBNSLyoqp+DuQ450oC1gMfu+13p6q+5k3cxpjjQ3hoCOcM6cZ7y0q9WgvIBJa3o9pmi0i8kwiWANNF5NHm9lHVOcCO5qoAceKaujbWqVt3RJ0fAB+o6j5v4jTGHL/OH96NygN1fLWuItChmBZ429XWVVX3AJcA01V1FHBWG8/9BDAYKAGWAberasMRda4AXj6i7AERWSoijzUO8fZERG4UkXwRyS8vt35fYzq7k/qmEB8VxvvLtgY6FNMCbxNPmIhkAJdxaHBBW50LFADdcXWtPSEi8Y0bnfMNBz5y2+duYBAwGkgC7mrq4Ko6TVXzVDUvNdUmFzSms4sIC+HsId34ZOVWauqO/B3WBBNvE8+fcCWADaq6QET6AOvaeO6pwBvqsh4owpVUGl0GzFTV2sYCVS116h8ApgNj2hiDMaYTuWB4N/ZU1/HNButuC2ZeJR5VnaGqI1T1Zudzoap+v43n3gRMABCRdGAgUOi2fQpHdLM5V0E494UmAR5HzBljjk+n9E8hNjKMD6y7Lah5O7ggS0RmOsOjt4nI6yKS1cI+LwNzgYEiUiwi14vITSJyk1PlPuAkEVkGzALuUtUKZ99soAfwxRGHfdGpvwxIAe73rpnGmONBZFgoZw1O46OVW6mtt+62YOXtsgjTcU2Rc6nz+Sqn7OymdlDVKc0dUFVLgHOa2LYRyPRQfqZ34RpjjlfnD8/gzYISvi3cwSn9UwIdjvHA23s8qao6XVXrnNezgN2xN8YEndMHpNIlPJQPV9jDpMHK28RTISJXiUio87oKsEXQjTFBJyo8lNMGpDBrVRnHw3pjHZG3iec6XKPMtgKluB7snOqvoIwxpi3OHtKN0t3VLN+yJ9ChGA+8HdW2SVUnqmqqqqap6iRcD5MaY0zQOXNQGiECn6y00W3BqC0rkP7cZ1EYY4wPJcVEkNcriY9Xbgt0KMaDtiQe8VkUxhjjY2cPSWf11r1s3mFTPQabtiQeu2tnjAlaZw9JB+DTVXbVE2yaTTwisldE9nh47cU1x5oxxgSl7JQY+qfF8ol1twWdZhOPqsaparyHV5yqevvwqTHGBMRZQ9L5tmgHu/fVtlzZtJu2dLUZY0xQO3tIOvUNyudrygIdinFjiccY02nlZCWQGhdp3W1BxhKPMabTCgkRzhqcxhdryzlQVx/ocIzDEo8xplM7e0g6lQfqmFe4I9ChGIclHmNMp3ZS3xSiI0L5b/7mQIdiHJZ4jDGdWlR4KDec0pv3lpby9XpbmTQYWOIxxnR6/++MfvRMiuZ3by63ez1BwBKPMabTiwoP5Y/fG0phRRXTvigMdDjHPb8mHhF5xlkue3kT27uKyDsiskREVojIVLdt9SJS4LzedivvLSLfisg6EXlVRCL82QZjTOdwxsA0zh/WjSc+X8+m7TZ/WyD5+4rnWeC8ZrbfAqxU1ZHAeOARt0SyX1VznNdEt33+F3hMVfsDO4HrfR+2MaYzuvfiIYSFCPe+vdwWiQsgvyYeVZ0DNDeGUYE4EREg1qlb11Rlp96ZwGtO0XPAJN9Ea4zp7DK6duFnZw9g9ppyps0p5LvtVZaAAiDQ8609AbwNlABxwOWq2uBsixKRfFyJ6CFVfRNIBnapamNyKgYy2zlmY0wHdu1J2byztJQHP1jNgx+sJi4qjCEZ8VwxpgeTc7MCHZ7P7Kyq4cMVWxk/MJWMrl0CHc5hAp14zgUKcF3F9AU+EZEvVXUP0FNVS0SkD/CZiCwDPK1j6/HXFRG5EbgRoGfPnn4J3hjT8YSFhjDjJyeyZutelpfsZvmW3cwt3M6vXltKXq8keiRFBzpEn1i7bS93v7GM/1w/JugST6BHtU0F3lCX9UARMAhAVUucPwuB2UAuUAEkiEhjwszCdbV0FFWdpqp5qpqXmprq31YYYzqUiLAQhmd1ZcqYnjwweTgv3TCOEBH++um6QIfmMyW79wMEXdKBwCeeTcAEABFJBwYChSKSKCKRTnkKcDKuQQgKfA78wNn/GuCtdo/aGNOpdOsaxdUn9mLm4mLWl+0NdDg+UbKrGoDuCVEBjuRo/h5O/TIwFxgoIsUicr2I3CQiNzlV7gNOcrrRZgF3qWoFMBjIF5EluBLNQ6q60tnnLuDnIrIe1z2fp/3ZBmPM8eHm8f3oEh7Ko5+sDXQoPlGyaz8J0eFERwT6jsrR/BqRqk5pYXsJcI6H8m+A4U3sUwiM8UmAxhjjSIqJ4IZT+/C3WetYVryb4VldAx1Sm5TurqZ7EHazQeC72owxJmjccGpvEqLD+cvHawIdSpuV7NoflN1sYInHGGMOiosK5+bT+/LF2nK+Ldwe6HDaxJV47IrHGGOC3tUnZpMWF8kjHfheT+WBOvZU1wXliDawxGOMMYfpEhHKj0/tw/yiHWworwx0OK1Suss1lNq62owxpoP4Xm53QgRmLtoS6FBaZcvBxGNXPMYY0yGkxUVxSv9UZi7eQkNDx5vLrXR34zM8lniMMabDuCQ3ky279rNgY3PzHAenkl37CRFIj4sMdCgeWeIxxhgPzhmaTnREKDMXd7zutpJd1aTHRxEWGpw/4oMzKmOMCbDoiDDOG9aN95aVUl3bsZbLDuah1GCJxxhjmnRJbhZ7q+uYtaos0KEck5Ld+8noGpwj2sASjzHGNOnEvsmkx0cyc3FxoEPxWkODUrq7mky74jHGmI4nNESYlJPJ7DXlbK88EOhwvLK9qoaauga74jHGmI5q8gmZ1DUo7y4tDXQoXindHdzP8IAlHmOMadagbvEMzojnjQ4yuq0kyB8eBUs8xhjTookju7Nk8y7K9lYHOpQWHVoAzhKPMcZ0WGN6JwFQsGlXgCNpWcmu/USGhZAYHR7oUJpkiccYY1owtHs84aHC4s3Bn3gaR7SJSKBDaZLfEo+IPCMiZSKyvIntXUXkHRFZIiIrRGSqU54jInOdsqUicrnbPs+KSJGIFDivHH/Fb4wxjaLCQxnSvSuLN+0MdCgt2rJrPxlBOit1I39e8TwLnNfM9luAlao6EhgPPCIiEcA+4GpVHers/1cRSXDb705VzXFeBf4J3RhjDpfbI4Glxbupq28IdCjNKt29P2iXvG7kt8SjqnOA5mbXUyBOXNeDsU7dOlVdq6rrnGOUAGVAqr/iNMYYb+T2TGBfTT1rtwXvGj01dQ2U7T1ARhAPLIDA3uN5AhgMlADLgNtV9bBfJURkDBABbHArfsDpgntMRIJz6lVjTKeT2yMRgMWbg7e7bduealQh8zjuamvJuUAB0B3IAZ4QkfjGjSKSAfwHmOqWkO4GBgGjgSTgrqYOLiI3iki+iOSXl5f7qQnGmONFj6QuJMdEsDiIR7Y1PsMTrEteNwpk4pkKvKEu64EiXEkFJwG9B9yjqvMad1DVUqf+AWA6MKapg6vqNFXNU9W81FTrqTPGtI2IkNszIagHGAT7AnCNApl4NgETAEQkHRgIFDoDDGYCz6vqDPcdnKsgnPtCkwCPI+aMMcYfcnsmsqG8it37agMdikeHlrwO7q62MH8dWERexjVaLUVEioHfA+EAqvokcB/wrIgsAwS4S1UrROQq4DQgWUSudQ53rTOC7UURSXXqFwA3+St+Y4w5Um4P1wDbguJdnD4g+HpSSnfvJyE6nOgIv/1o9wm/RaeqU1rYXgKc46H8BeCFJvY50zfRGWPMsRvRIwERWLxpZ1AmnpJd1UE/lBps5gJjjPFabGQYA9PjgnaAgWvl0eDuZgNLPMYYc0xyeyZQsHkXDQ0a6FCOEuxLXjeyxGOMMccgt0ciu/fXUrS9KtChHKbyQB17quuCfig1WOIxxphjktvTNcAg2LrbSjvIiDawxGOMMcekb2oscZFhQfc8z5YOsABcI0s8xhhzDEJChJyeCUF3xbN5xz4AeiRGBziSllniMcaYY5TbI4HVW/dQdaAu0KEctKG8ipiIUNLjg38KS0s8xhhzjMb1TaZB4bPVZYEO5aDCiip6p8YE9QJwjSzxGGPMMRrXO5nMhC78N39zoEM5qKiikt4psYEOwyuWeIwx5hiFhAjfH5XFV+srDt7UD6Tq2nqKd+6nT0pMoEPxiiUeY4xphUtHZaEKbywsDnQofLd9H6rQJ9USjzHGdFo9kqI5qW8yMxYWB3wWg6IK16qofayrzRhjOrfL8nqwacc+vi3aEdA4NpS7ZlHobVc8xhjTuZ03rBtxUWHMCPAgg6KKKtLjI4mNDO7lEBpZ4jHGmFaKCg/l4pHdeX95KXuqA7c4XGF5Jb07yMACsMRjjDFtclleD6prG3hvaWnAYiisqKJPase4vwOWeIwxpk1GZnVlQHpswJ7p2VlVw659tR1mKDVY4jHGmDYRES7L68HiTbtYs3Vvu5+/sHFEWwcZWAB+Tjwi8oyIlInI8ia2dxWRd0RkiYisEJGpbtuuEZF1zusat/JRIrJMRNaLyOPSEeaHMMZ0apeckEWX8FD+74sN7X7uxhFtHWUoNfj/iudZ4Lxmtt8CrFTVkcB44BERiRCRJOD3wFhgDPB7EUl09vkXcCPQ33k1d3xjjPG7pJgIrhzbk7eWlPBdOy8QV1RRRXiokJUY/MshNPJr4lHVOUBzA9wViHOuWmKdunXAucAnqrpDVXcCnwDniUgGEK+qc1VVgeeBSf5sgzHGeOPHp/UhNER4sp2vegrLK+mZFE1YaMe5cxLoSJ8ABgMlwDLgdlVtADIB9zt1xU5ZpvP+yPKjiMiNIpIvIvnl5eX+iN0YYw5Kj4/i8rwevLawmJJ2nL+tsLxjjWiDwCeec4ECoDuQAzwhIvGAp/s22kz50YWq01Q1T1XzUlNTfRWvMcY06Sen90EVps0pbJfz1Tco323f16FGtEHgE89U4A11WQ8UAYNwXcn0cKuXheuqqNh5f2S5McYEXFZiNJNzM3l5/ibK9x7w+/m27NxPTX1DhxrRBoFPPJuACQAikg4MBAqBj4BzRCTRGVRwDvCRqpYCe0VknHNf6GrgrcCEbowxR7t5fF9q6xt46iv/X/UcGkptXW0HicjLwFxgoIgUi8j1InKTiNzkVLkPOElElgGzgLtUtUJVdzjbFjivPzllADcDTwHrgQ3AB/5sgzHGHIs+qbFcNKI7L8z9jp1VNX49V2Hj5KAdrKvNrzPKqeqUFraX4Lqa8bTtGeAZD+X5wDCfBGiMMX5wyxn9eGdpCX//bD33XjzEb+cprKgkPiqM5JgIv53DHwLd1WaMMZ3OwG5xXDG6J8/N3cjabf6bzaDImaOtoz1Hb4nHGGP84M5zBxIXFca9by3H9dih7xWWV3W4EW1giccYY/wiKSaCX54zkHmFO3jXDzNX76upo3R3dYcb0QaWeIwxxm+mjOnJsMx4HnhvFVUH6nx67KIKZ462DjaiDSzxGGOM34SGCH+cOIyte6r5+2frfXrsjjqiDSzxGGOMX43qlcgPRmXx9FeFzF5TRl19g0+OO69wO1HhIR0y8XSMBbqNMaYD+/X5g5i9ppxrpy+ga5dwxg9M5cxBaZw9JJ3oiGP/Mby/pp63C0q4YFgGUeGhfojYvyzxGGOMn6XERjL7zvF8ta6cT1eV8fnqMt4qKKF3Sgz/uuoEBnWLP6bjfbC8lL0H6rhsdI+WKwchSzzGGNMOYiPDOG9YBucNy6ChQflyfQW/nLGESf/4mgcvGc7k3KyWD+J4dcFmspOjGds7yY8R+4/d4zHGmHYWEiKcPiCV9247hRFZCfzs1SX87s3lHKirb3HfjRVVfFu0g0vzenS4B0cbWeIxxpgASYuL4sUbxnLjaX34z7zvmDp9AdW1zSef/+ZvJkTgB6O8v0IKNpZ4jDEmgMJDQ/jNBYP5y6Uj+WbDdn72agH1DZ5nOqirb+C1hcWcMTCN9Piodo7UdyzxGGNMEPjBqCx+d9EQPli+ld81Mc3OF2vLKdt7oMMOKmhkgwuMMSZIXH9Kb7ZXHuCfszeQEhvJz88ecNj2VxdsJiU2gjMHpQUoQt+wxGOMMUHkznMHsr2yhsdnrWPfgTpO7pdC//RYIsJC+Gx1Gded0pvw0I7dWWWJxxhjgoiI8MDkYVTV1PHUV0U89VURAGEhQl2Dcllex+5mA0s8xhgTdMJCQ3jihydw/6Qa1pdVsnZbJevK9pIcE0G/tI43KeiR/JZ4ROQZ4CKgTFWPWjFURO4ErnSLYzCQ6rxedavaB7hXVf8qIn8AfgyUO9t+o6rv+6cFxhgTWAnREeRlJ5GX3TEfFG2KP694ngWeAJ73tFFV/wz8GUBELgZ+pqo7gB1AjlMeCmwBZrrt+piq/sV/YRtjjPEnv92hUtU5uJKIN6YAL3sonwBsUNXvfBaYMcaYgAr40AgRiQbOA173sPkKjk5IPxWRpSLyjIgk+j1AY4wxPhXwxANcDHztdLMdJCIRwERghlvxv4C+uLriSoFHmjqoiNwoIvkikl9eXt5UNWOMMe0sGBKPp6sagPOBRaq6rbFAVbepar2qNgD/BsY0dVBVnaaqeaqal5qa6vOgjTHGtE5AE4+IdAVOB97ysPmo+z4ikuH2cTKw3H/RGWOM8Qd/Dqd+GRgPpIhIMfB7IBxAVZ90qk0GPlbVqiP2jQbOBn5yxGEfFpEcQIGNHrYbY4wJcn5LPKo6xYs6z+Iadn1k+T4g2UP5j3wRmzHGmMARTzOgdjYiUg4cOSS7K7C7hTL3zy29TwEq2hCmp3i8rXOsbTnys6/b05a2NLXteP9u3Mvsu/Eu1pbqdKbvxpu2HFnmzXcTo6q+v0muqsflC5jWUpn755beA/m+jsfbOsfaFn+3py1tse+myTa4l9l3Y9/NMbelvb+b5l7BMKotUN7xouydY3zv63i8rXOsbTnys6/b05a2NLXteP9ugqEtTW2z78Y3/N2WI8v8/d006bjoamsPIpKvqnmBjsNXOlN7OlNboHO1pzO1BTpXe/zZluP5isfXpgU6AB/rTO3pTG2BztWeztQW6Fzt8Vtb7IrHGGNMu7IrHmOMMe3KEo8HzgSkZSJyzDMjiMgoEVkmIutF5HEREbdtt4rIGhFZISIP+zbqZmPyeXtE5A8iskVECpzXBb6P3GM8fvlunO2/FBEVkRTfRdxiTP74bu5zJtItEJGPRaS77yP3GI8/2vJnEVnttGemiCT4PnKP8fijLZc6//cbRMTv94Ha0oYmjneNiKxzXte4lTf7/8ojfw2X68gv4DTgBGB5K/adD5wICPABcL5TfgbwKRDpfE7r4O35A/DLzvDdONt6AB/het4rpSO3B4h3q3Mb8GQHbss5QJjz/n+B/+3AbRkMDARmA3nB2gYnvuwjypKAQufPROd9YnPtbe5lVzweqIe1hESkr4h8KCILReRLERl05H7OXHLxqjpXXd/I88AkZ/PNwEOqesA5R5l/W3GIn9oTEH5sy2PAr3BNx9Ru/NEeVd3jVjWGdmqTn9rysarWOVXnAVn+bYWLn9qySlXXtEf8zvla1YYmnAt8oqo7VHUn8AlwXmt/Rlji8d404FZVHQX8EvinhzqZQLHb52KnDGAAcKqIfCsiX4jIaL9G27K2tgeCZ22kNrVFRCYCW1R1ib8D9VKbvxsReUBENuNaXv5eP8baEl/8O2t0Ha7fqAPFl20JFG/a4EkmsNntc2O7WtVefy593WmISCxwEjDDrfsy0lNVD2WNv22G4bpEHQeMBv4rIn2c3xLalY/a8y/gPufzfbjWRrrOt5G2rK1tEdeEtL/F1aUTcD76blDV3wK/FZG7gZ/imqS3XfmqLc6xfgvUAS/6MkZv+bItgdJcG0RkKnC7U9YPeF9EaoAiVZ1M0+1qVXst8XgnBNilqjnuhSISCix0Pr6N64exe1dAFlDivC8G3nASzXwRacA1F1IgVqlrc3vUbZ0kEfk38K4/A25GW9vSF+gNLHH+M2YBi0RkjKpu9XPsnvji35q7l4D3CEDiwUdtcW5kXwRMCMQvag5ffy+B4LENAKo6HZgOICKzgWtVdaNblWJcqw00ysJ1L6iY1rTX3ze4OuoLyMbtphzwDXCp816AkU3stwDXVU3jjbYLnPKbgD857wfgumyVDtyeDLc6PwNe6ahtOaLORtpxcIGfvpv+bnVuBV7rwG05D1gJpLbnd+LPf2e00+CC1raBpgcXFOHqtUl03id5016PcbX3l9kRXrgWoCsFanFl9Otx/Vb8IbDE+Y9wbxP75uFaoG4D8ASHHtKNAF5wti0Czuzg7fkPsAxYius3vYyO2pYj6mykfUe1+eO7ed0pX4pr3q3MDtyW9bh+SStwXu01Qs8fbZnsHOsAsA34KBjbgIfE45Rf53wf64GpLbW3uZfNXGCMMaZd2ag2Y4wx7coSjzHGmHZliccYY0y7ssRjjDGmXVniMcYY064s8ZjjkohUtvP5nhKRIT46Vr24Zp5eLiLvtDRjs4gkiMj/88W5jfEFG05tjksiUqmqsT48XpgemszSr9xjF5HngLWq+kAz9bOBd1V1WHvEZ0xL7IrHGIeIpIrI6yKywHmd7JSPEZFvRGSx8+dAp/xaEZkhIu8AH4vIeBGZLSKviWsNmRcb1yZxyvOc95XOJJ5LRGSeiKQ75X2dzwtE5E9eXpXN5dBkp7EiMktEFolrfZTvOXUeAvo6V0l/dure6ZxnqYj80Yd/jca0yBKPMYf8DXhMVUcD3weecspXA6epai6umZ7/x22fE4FrVPVM53MucAcwBOgDnOzhPDHAPFUdCcwBfux2/r85529xvitnnrAJuGaOAKgGJqvqCbjWf3rESXy/Bjaoao6q3iki5wD9gTFADjBKRE5r6XzG+IpNEmrMIWcBQ9xm7o0XkTigK/CciPTHNfNuuNs+n6iq+5on81W1GEBECnDNlfXVEeep4dCkqguBs533J3JoLZOXgL80EWcXt2MvxLU2CrjmyvofJ4k04LoSSvew/znOa7HzORZXIprTxPmM8SlLPMYcEgKcqKr73QtF5O/A56o62blfMtttc9URxzjg9r4ez//HavXQzdWm6jRnv6rmiEhXXAnsFuBxXGvvpAKjVLVWRDYCUR72F+BBVf2/YzyvMT5hXW3GHPIxrrVrABCRxunjuwJbnPfX+vH883B18QFc0VJlVd2Na2nrX4pIOK44y5ykcwbQy6m6F4hz2/Uj4DpnfRZEJFNE0nzUBmNaZInHHK+iRaTY7fVzXD/E85wb7itxLWUB8DDwoIh8DYT6MaY7gJ+LyHwgA9jd0g6quhjXTMNX4FokLU9E8nFd/ax26mwHvnaGX/9ZVT/G1ZU3V0SWAa9xeGIyxq9sOLUxQcJZDXW/qqqIXAFMUdXvtbSfMR2N3eMxJniMAp5wRqLtIgBLiRvTHuyKxxhjTLuyezzGGGPalSUeY4wx7coSjzHGmHZliccYY0y7ssRjjDGmXVniMcYY067+PzE38fn93wmuAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "learn.lr_find()\n",
+    "learn.recorder.plot(skip_end=15)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "Total time: 00:30 <p><table style='width:300px; margin-bottom:10px'>\n",
+       "  <tr>\n",
+       "    <th>epoch</th>\n",
+       "    <th>train_loss</th>\n",
+       "    <th>valid_loss</th>\n",
+       "  </tr>\n",
+       "  <tr>\n",
+       "    <th>1</th>\n",
+       "    <th>0.923900</th>\n",
+       "    <th>0.946068</th>\n",
+       "  </tr>\n",
+       "  <tr>\n",
+       "    <th>2</th>\n",
+       "    <th>0.865458</th>\n",
+       "    <th>0.890646</th>\n",
+       "  </tr>\n",
+       "  <tr>\n",
+       "    <th>3</th>\n",
+       "    <th>0.783896</th>\n",
+       "    <th>0.836753</th>\n",
+       "  </tr>\n",
+       "  <tr>\n",
+       "    <th>4</th>\n",
+       "    <th>0.638374</th>\n",
+       "    <th>0.815428</th>\n",
+       "  </tr>\n",
+       "  <tr>\n",
+       "    <th>5</th>\n",
+       "    <th>0.561979</th>\n",
+       "    <th>0.814652</th>\n",
+       "  </tr>\n",
+       "</table>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "learn.fit_one_cycle(5, 5e-3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "learn.save('dotprod')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here's [some benchmarks](https://www.librec.net/release/v1.3/example.html) on the same dataset for the popular Librec system for collaborative filtering. They show best results based on RMSE of 0.91, which corresponds to an MSE of `0.91**2 = 0.83`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Interpretation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "learn.load('dotprod');"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "EmbeddingDotBias(\n",
+       "  (u_weight): Embedding(944, 40)\n",
+       "  (i_weight): Embedding(1654, 40)\n",
+       "  (u_bias): Embedding(944, 1)\n",
+       "  (i_bias): Embedding(1654, 1)\n",
+       ")"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "learn.model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array(['Star Wars (1977)', 'Contact (1997)', 'Fargo (1996)', 'Return of the Jedi (1983)', 'Liar Liar (1997)',\n",
+       "       'English Patient, The (1996)', 'Scream (1996)', 'Toy Story (1995)', 'Air Force One (1997)',\n",
+       "       'Independence Day (ID4) (1996)'], dtype=object)"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "g = rating_movie.groupby(title)['rating'].count()\n",
+    "top_movies = g.sort_values(ascending=False).index.values[:1000]\n",
+    "top_movies[:10]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Movie bias"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "torch.Size([1000])"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "movie_bias = learn.bias(top_movies, is_item=True)\n",
+    "movie_bias.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mean_ratings = rating_movie.groupby(title)['rating'].mean()\n",
+    "movie_ratings = [(b, i, mean_ratings.loc[i]) for i,b in zip(top_movies,movie_bias)]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "item0 = lambda o:o[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[(tensor(-0.3667),\n",
+       "  'Children of the Corn: The Gathering (1996)',\n",
+       "  1.3157894736842106),\n",
+       " (tensor(-0.3142),\n",
+       "  'Lawnmower Man 2: Beyond Cyberspace (1996)',\n",
+       "  1.7142857142857142),\n",
+       " (tensor(-0.2926), 'Mortal Kombat: Annihilation (1997)', 1.9534883720930232),\n",
+       " (tensor(-0.2708), 'Cable Guy, The (1996)', 2.339622641509434),\n",
+       " (tensor(-0.2669), 'Striptease (1996)', 2.2388059701492535),\n",
+       " (tensor(-0.2641), 'Free Willy 3: The Rescue (1997)', 1.7407407407407407),\n",
+       " (tensor(-0.2511), 'Beautician and the Beast, The (1997)', 2.313953488372093),\n",
+       " (tensor(-0.2418), 'Bio-Dome (1996)', 1.903225806451613),\n",
+       " (tensor(-0.2345), \"Joe's Apartment (1996)\", 2.2444444444444445),\n",
+       " (tensor(-0.2324), 'Island of Dr. Moreau, The (1996)', 2.1578947368421053),\n",
+       " (tensor(-0.2266), 'Barb Wire (1996)', 1.9333333333333333),\n",
+       " (tensor(-0.2219), 'Crow: City of Angels, The (1996)', 1.9487179487179487),\n",
+       " (tensor(-0.2208), 'Grease 2 (1982)', 2.0),\n",
+       " (tensor(-0.2151), 'Home Alone 3 (1997)', 1.894736842105263),\n",
+       " (tensor(-0.2089), \"McHale's Navy (1997)\", 2.1884057971014492)]"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sorted(movie_ratings, key=item0)[:15]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[(tensor(0.5913), \"Schindler's List (1993)\", 4.466442953020135),\n",
+       " (tensor(0.5700), 'Titanic (1997)', 4.2457142857142856),\n",
+       " (tensor(0.5623), 'Shawshank Redemption, The (1994)', 4.445229681978798),\n",
+       " (tensor(0.5412), 'L.A. Confidential (1997)', 4.161616161616162),\n",
+       " (tensor(0.5368), 'Rear Window (1954)', 4.3875598086124405),\n",
+       " (tensor(0.5193), 'Star Wars (1977)', 4.3584905660377355),\n",
+       " (tensor(0.5149), 'As Good As It Gets (1997)', 4.196428571428571),\n",
+       " (tensor(0.5114), 'Silence of the Lambs, The (1991)', 4.28974358974359),\n",
+       " (tensor(0.5097), 'Good Will Hunting (1997)', 4.262626262626263),\n",
+       " (tensor(0.4946), 'Vertigo (1958)', 4.251396648044692),\n",
+       " (tensor(0.4899), 'Godfather, The (1972)', 4.283292978208232),\n",
+       " (tensor(0.4855), 'Boot, Das (1981)', 4.203980099502488),\n",
+       " (tensor(0.4769), 'Usual Suspects, The (1995)', 4.385767790262173),\n",
+       " (tensor(0.4743), 'Casablanca (1942)', 4.45679012345679),\n",
+       " (tensor(0.4665), 'Close Shave, A (1995)', 4.491071428571429)]"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sorted(movie_ratings, key=lambda o: o[0], reverse=True)[:15]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Movie weights"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "torch.Size([1000, 40])"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "movie_w = learn.weight(top_movies, is_item=True)\n",
+    "movie_w.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "torch.Size([1000, 3])"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "movie_pca = movie_w.pca(3)\n",
+    "movie_pca.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fac0,fac1,fac2 = movie_pca.t()\n",
+    "movie_comp = [(f, i) for f,i in zip(fac0, top_movies)]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[(tensor(1.2412), 'Home Alone 3 (1997)'),\n",
+       " (tensor(1.2072), 'Jungle2Jungle (1997)'),\n",
+       " (tensor(1.2000), 'Bio-Dome (1996)'),\n",
+       " (tensor(1.1883), 'Leave It to Beaver (1997)'),\n",
+       " (tensor(1.1570), 'Children of the Corn: The Gathering (1996)'),\n",
+       " (tensor(1.1309), \"McHale's Navy (1997)\"),\n",
+       " (tensor(1.1187), 'D3: The Mighty Ducks (1996)'),\n",
+       " (tensor(1.0956), 'Congo (1995)'),\n",
+       " (tensor(1.0950), 'Free Willy 3: The Rescue (1997)'),\n",
+       " (tensor(1.0524), 'Cutthroat Island (1995)')]"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sorted(movie_comp, key=itemgetter(0), reverse=True)[:10]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[(tensor(-1.0692), 'Casablanca (1942)'),\n",
+       " (tensor(-1.0523), 'Close Shave, A (1995)'),\n",
+       " (tensor(-1.0142), 'When We Were Kings (1996)'),\n",
+       " (tensor(-1.0075), 'Lawrence of Arabia (1962)'),\n",
+       " (tensor(-1.0034), 'Wrong Trousers, The (1993)'),\n",
+       " (tensor(-0.9905), 'Chinatown (1974)'),\n",
+       " (tensor(-0.9692), 'Ran (1985)'),\n",
+       " (tensor(-0.9541), 'Apocalypse Now (1979)'),\n",
+       " (tensor(-0.9523), 'Wallace & Gromit: The Best of Aardman Animation (1996)'),\n",
+       " (tensor(-0.9369), 'Some Folks Call It a Sling Blade (1993)')]"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sorted(movie_comp, key=itemgetter(0))[:10]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "movie_comp = [(f, i) for f,i in zip(fac1, top_movies)]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[(tensor(0.8788), 'Ready to Wear (Pret-A-Porter) (1994)'),\n",
+       " (tensor(0.8263), 'Keys to Tulsa (1997)'),\n",
+       " (tensor(0.8066), 'Nosferatu (Nosferatu, eine Symphonie des Grauens) (1922)'),\n",
+       " (tensor(0.7730), 'Dead Man (1995)'),\n",
+       " (tensor(0.7513), 'Three Colors: Blue (1993)'),\n",
+       " (tensor(0.7492), 'Trainspotting (1996)'),\n",
+       " (tensor(0.7414), 'Cable Guy, The (1996)'),\n",
+       " (tensor(0.7330), 'Jude (1996)'),\n",
+       " (tensor(0.7246), 'Clockwork Orange, A (1971)'),\n",
+       " (tensor(0.7195), 'Stupids, The (1996)')]"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sorted(movie_comp, key=itemgetter(0), reverse=True)[:10]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[(tensor(-1.2148), 'Braveheart (1995)'),\n",
+       " (tensor(-1.1153), 'Titanic (1997)'),\n",
+       " (tensor(-1.1148), 'Raiders of the Lost Ark (1981)'),\n",
+       " (tensor(-0.8795), \"It's a Wonderful Life (1946)\"),\n",
+       " (tensor(-0.8644), \"Mr. Holland's Opus (1995)\"),\n",
+       " (tensor(-0.8619), 'Star Wars (1977)'),\n",
+       " (tensor(-0.8558), 'Return of the Jedi (1983)'),\n",
+       " (tensor(-0.8526), 'Pretty Woman (1990)'),\n",
+       " (tensor(-0.8453), 'Independence Day (ID4) (1996)'),\n",
+       " (tensor(-0.8450), 'Forrest Gump (1994)')]"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sorted(movie_comp, key=itemgetter(0))[:10]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA7IAAANSCAYAAABYxPJ2AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvOIA7rQAAIABJREFUeJzs3Xd0FcXDxvFn00MJISSUhN57kdB7k15ERFBRimJHVFAQUeCHimLBAiIWUCyIiPTelA6BgIQSQKkJJLSQBNLuvfv+EbkvISEEiQkL3885npPdmZ2ZXY7Aw8zOGqZpCgAAAAAAq3DJ7QEAAAAAAHAzCLIAAAAAAEshyAIAAAAALIUgCwAAAACwFIIsAAAAAMBSCLIAAAAAAEshyAIAAAAALIUgCwAAAACwFIIsAAAAAMBS3HJ7ANfj7+9vli5dOreHAQAAAAC5YseOHWdN0wzI7XHcjm7bIFu6dGmFhITk9jAAAAAAIFcYhnEst8dwu2JpMQAAAADAUgiyAAAAAABLIcgCAAAAACyFIAsAAAAAsBSCLAAAAADAUgiyAAAAAABLIcgCAAAAACyFIAsAAAAAsBSCLAAAAADAUgiyAAAAAABLIcgCAAAAACyFIAsAAAAAsBSCLAAAAADAUgiyAAAAAABLIcgCAAAAACyFIAsAAAAAsBSCLAAAAADAUgiyAAAAAABLIcgCAAAAACyFIAsAAAAAsBSCLAAAAADAUgiyAAAAAABLIcgCAAAAACyFIAsAAAAAsBSCLAAAAADAUgiyAAAAAABLIcgCAAAAACyFIAsAAAAAsBSCLAAAAADAUgiyAAAAAABLIcgCANSuyxK1aLdQjVrOV+GSM9Wi3UK1aLdQz7248T/r0253qEW7hUpOtv/rNi5cSNJnU/dm46hSrVx90vkMqtSercq1ZjuPl644oSefX6/p34Xfcj/xl1LUuuNiJSTYJEkfTw5T/aa/yb/4d1q9NiJN3W3bo3VvlyVq1naB2nZerLC959OUte28WC3aLVTjVvP13Q8H0/X1/U+HVCjo/9tNTLSrdcfFiotPueX7AAAgp7nl9gAAALlv5aJOkqTjJ+LVpuNi/b6y6023YZqmHA5Trq5Z+zdSV1eXf9XP1S7EJGny1L167qlqN32tzeaQm1vGY23XprjatSkuSXrr3VDZ7A69+VpdZ/m8hUf/1Xiv9cVX+3Vft1Ly9k7947hZk6Lq1rmUnh26IU09h8NU/8G/a8a0Fqpfr7A2bDqtp4Zs0IbV3SRJL766ReNG11WbVkE6dfqy6jX5TV06lpSfn5ck6WREvH6YdVh1ahdytunl5aqe3Uvriy/3a9iLNbPlfgAAyCkEWQDADf0w65Cmzzwou81UgQIe+mBCQ5Ur66OZPx7S4qXHVaCAhw4euqgpHzfRyyO2qF7dAG3fcUYnTl7SM4OrqlAhL30944CiohP0vzeD1bVTKdlsDhUp9b0i/npYXl6uql53jh7pW15r1kUq+kyChjxTXQMfqyRJGvXmdm3ZHq2UZIf8/b306QeNFRSUV6+M2qrzF5LUot1C5cvnrsW/ddDhv2L18ogtOn8hUe5uLhr92j1q1TzQ2d/Y0XW1fOVJNWtSVK+8VOtfP5O9+y+oe6/lijh1WQ3rF9anHzaWYRiKjU3Wa29u14GDMUpKsqtF02Ia90awXFyMdG3M/PGQlszr6Dy+p7Z/hn1Fn0nQ5QSb6tcrLElq2riojh6NU9je86pezU+GIcXGJkuS4uNT5FPAQ17/hGPTNDV0+Ga9Pa6eRr25PU27PbuXUcfuSwmyAADLIcgCADK1YdNpLVl2Qkt+6yAPD1ctW3FCQ4dv1sJf20uSNm+L1vpVXVWyRD7nNaejErRobgedOn1ZDZrN07NPVdPyhZ20bXu0Bj+3Xl07lcqwr6Rku1Ys6qSjx+LUvO1C9e1dTt7ebnrphRoq9M/s4vTvwjVuwk598WkzvfdWA3W+b1mamd3Bz/6hJwZWUd/e5bRv/wX16L1CW37vLh8fD0mSITnHfivCD17UnB/bSpKat1uoDZui1KxJUY18Y7tatwzUZx81kcNh6vGn/9BPv/ylhx8sn+b6Y8fjZLOZCiyW54Z9FSnsrXx53bVi1Und27a4Fi09roREu05EXFL1an6aPKmJ+g1cqzfH71BMTLKmTW6mPP8E2S+nH1DNGoVUp1b6kBxYLI9M09TfR2JVtozPLT8TAAByCkEWAO5i80IjNHF5uCJjEhTo660BtUumq7NsxQnt3nNe7TovkSSZZuq7nVc0blA4TYiVpG5dSsnFxVBQYF75+HioS8fUdmvVLKQTJy8pJcUhI/0EpXp2KyNJKl0qv/Llc9ep05dVtoyPVqyK0DffhevyZZtSUhxyd894SXBMTJLCD11UnwfKSpKqVimoypV8tXPXObVsXkyS1Kd3uZt8Shnr3KGEPD1dJUk1q/vp6LE4NWtSVMtXntCfYef0yeQwSVJCgk2lS+dPd33kqcsqHOCVpb4Mw9DMb1pq7Fs79c7EXapfL0Dly/nI/Z+l0Z9MDtNbY+upa6dSCj8Uo559VqpGdT8lJdk165e/tXReh+u2XbiwtyJPXSbIAgAshSALAHepeaERGjl3jxJSUjdbiohJ0HvLwpVsd6SpZ5rSY49U0PAXM16Gmzeve7pzXv8EPElycTHk6ZV67Oqaml7tdlNubumT7JV6V66z2U0dPRanN/8XolVLOqtkiXzatCVKQ17edN37yiAfpwnNefOkH++/4Xn1PboastlSn5vDlH76trWKB+W73qWSUt9RTUzK+kZXdWr5a97seyWlbtRUufZsVSjvo6joBK1aG6mvp7aQJFWq4KtKFXwVuvucLl1K0alTl9Sg+TxJqUuUnx26UWNer6s+D6QG+qQku7yueu4AAFgBuxYDwF1q4vJwZ4i9ItFmV8I1uwh3uLeEZv3yl06dviwpdbfhXX+ey7FxxsYly9PTVUUKe8vhMPXt9/+/I2/+/O66dNkm+z/h29fXUxUrFNDsX/+WJB0Ij9GB8BjVqVUow7ZPRsSrSesF2TreDu2Ka9JnYc4xnT2XqGPH49LVq1ihgCIiLyslxZGuLCNR0QnOnz/85E+1bFZMpUrml19BTxmGtHV7tCTp1OnL2rf/gipVKKAHe5XT/l29tWvr/dq19X7VrllIkyc1cYZYm82hEycvqXIl31u9bQAAchQzsgBwl4qMScjwvMM00xw3a1JUw1+spb6PrpbDIaXYHLqvW2nVrplxOMxuNasXUsf2JdSo5XwVD8qrRg2KaEfoWUlSgL+3unUupSatF6qQn6cW/9ZB0yY318sjtmjy1H1ydTX0xeRm8vPzcs6YXu3UqQS5uWY0h/vvTRhfX2P+t0PN2y2SYaTO3L4ztp5KlUy7vDhvHnc1ql9Ym7ZEqUWz1GXPH326R1/PCNe584l6esgGeXi4atuGHsrj7aavZxzQvIXHZLc7VLeOvyZNbCRJcnd30VdTmuvVUVvlcEh2h6nXR9RRhfIFbjjWTVui1LBeYeXLYFYdAIDbmWFe8xeW20VwcLAZEhKS28MAgDtWkwlrFJFBmA3y9dbGEa1zYUQ575MpYSoelFc9u5fJlf43b43S1K/269svW+ZK/wOf/F0DH6ukpo2L5kr/AIDMGYaxwzTN4Nwex+2IpcUAcJca3r6SvN3Tvhvp7e6q4e0r5dKIct6QZ6rnWoiVpEYNiqhNy0AlJNhyvO/ERLuaNy1GiAUAWBIzsgBwF7t21+Lh7SupR52g3B4WAAAQM7KZyZZ3ZA3D+EZSF0nRpmlWz6DckPSxpE6SLkvqb5rmzuzoGwDw7/WoE0RwBQAAlpNdS4tnSLr+R+qkjpIq/PPfYEmfZ1O/AAAAAIC7TLYEWdM0/5B0PpMq3SV9Z6baIsnXMIxi2dE3AAAAAODuklObPQVJOnHV8cl/zqVhGMZgwzBCDMMIOXPmTA4NDQAAAABgJTkVZDP6SF+6XaZM05xmmmawaZrBAQEBOTAsAAAAAIDV5FSQPSmpxFXHxSVF5lDfAAAAAIA7SE4F2QWSHjVSNZR00TTNUznUNwAAAADgDpJdn9/5SVJLSf6GYZyU9KYkd0kyTXOqpCVK/fTOYaV+fmdAdvQLAAAAALj7ZEuQNU2z7w3KTUnPZkdfAAAAAIC7W04tLQYAAAAAIFsQZAEAAAAAlkKQBQAAAABYCkEWAAAAAGApBFkAAAAAgKUQZAEAAAAAlkKQBQAAAABYCkEWAAAAAGApBFkAAAAAgKUQZAEAAAAAlkKQBQAAAABYCkEWAAAAAGApBFkAAAAAgKUQZAEAAAAAlkKQBQAAAABYCkEWAAAAAGApBFkAAAAAgKUQZAEAAAAAlkKQBQAAAABYCkEWAAAAAGApBFkAAAAAgKUQZAEAAAAAlkKQBQAAAABYCkEWAAAAAGApBFkAAAAAgKUQZAEAAAAAlkKQBQAAAABYCkEWAAAAAGApBFkAAAAAgKUQZAEAAAAAlkKQBQAAAABYCkEWAAAAAGApBFkAAAAAgKUQZAEAAAAAlkKQBQAAAABYCkEWAAAAAGApBFkAAAAAgKUQZAEAAAAAlkKQBQAAAABYCkEWAAAAAGApBFkAAAAAgKUQZAEAAAAAlkKQBQAAAABYCkEWAAAAAGApBFkAAAAAgKUQZAEAAAAAlkKQBQAAAABYCkEWAAAAAGApBFkAAAAAgKUQZAEAAAAAlkKQBQAAAABYCkEWAAAAAGApBFkAAAAAgKUQZAEAAAAAlkKQBQAAAABYCkEWAAAAAGApBFkAAAAAgKUQZAEAAAAAlkKQBQAAAABYCkEWAAAAAGApBFkAAAAAgKUQZAEAAAAAlkKQBQAAAABYCkEWAAAAAGApBFkAAAAAgKUQZAEAAAAAlkKQBQAAAABYCkEWAAAAAGApBFkAAAAAgKUQZAEAAAAAlkKQBQAAAABYCkEWAAAAAGApBFkAAAAAgKUQZAEAAAAAlkKQBQAAAABYCkEWAAAAAGApBFkAAAAAgKUQZAEAAAAAlkKQBQAAAABYiltuDwAAAGS/YY+OUEpyimwpNkUcj1SpciUlSWUrldELY5/7T/q02+166eFX9P7MCXJ3d/9XbcRdjNOq+Wt036Pdb308NrveffUDnfj7hNw93OVbyFfPvDZYRYsXveG1rw4cpd6Deqlukzo31ee/vS673eg5Rh4/pWd7vaCSZUvI4XDIZrOpWp2q6vtkbxUqXChbxzL+xQnq+2RvlatcVjs27tQPU2bp6KFj6v5IFz02pJ+z3rkz5zVl/FSdOX1WdptdvZ/opRYdmt2wLLM2v/5guirVrKSm7Rpn6z0ByH0EWQAA7kDvfzdBkhQVGa2XHnlFH8/64KbbME1TDodDrq6uWarv6ur6r/q5WtzFeP02c8G/CrJ2m12ubmnH2q57awU3qyvDMDT/h0X6/O1pGjvljVsaoxVk5TnmL5Df+euVkpyiWdNm69UBo/TJ7I+UJ693toxj364DctjtKle5rCSpWImieu6Np7V++YZ0db96/xtVrlVZoz/uqQvnYvTyI6+oet1qKhTgl2lZZm32fKyHRg1+U03aNpJhGNlyTwBuDwRZAADuQivnrdayX1fIbrcrX/58embUYAWWDNSK31Zpy9qtyps/r04cOakXxw3RlLe/UOUaFXVgz0GdOXVG3R/uKp+CPloye5kunL2ggS/1V+M2DWW32XVf/d6as/kneXh6aECHJ9Suexvt3LxLMedi1LN/D3V6oIMk6av3p2vfrv2ypdhUwK+Ahrz5rAKK+uuLCV8q7mKcXujzsrzzeGvCN+MVcSxSU976QrExsXJzc9OjQx5RnYa1nP0NGPqotv0Ropr1aqjvk72d9+jq5qp6zYOdx5VrVtSyX5ff9LO6dpb16uNjh4/rk7GT5bA7VLJcCaUkpzivO3b4uD4e85lSklNUtlIZnTwaoYee6qO6Tero1YGjsvRMJenA7nB999kPSrycKEl6+Jk+qtvkHkUeP6URg15Xm64ttXPzbiUnJWnIm8+qSq3KGT7HzLh7uKvfcw8rdMtu/bF0vTr0ule/zpinjas2yW6zy8PTQ8+MelJlKpbW7K9/1cXzF/XE8IGSUmdLX3xouL5a9Lk8PD3StLt87ko1/2fmVJICSwZKkjat2iy73Z6m7tGDx9RrQE9JUsFCvipVvqQ2rtykbg91ybQsszYL+hdUoSKFtCckTDXr1bjRLzUACyHIAgBwl9kTEqat67Zpwjfj5e7urm2/b9en4z7XO1/9T5K0N3S/Pvn5QxUJLOy85vzZC3rnq//p/JkLeuq+53Rfv26a+O072r/7gD54bZIzdF0rJSVF7383QadPntaQB19Wm66t5Onlqd6D7pdPQR9J0tI5y/Xdpz/o5bde0JMjntCIQa+nmdl9f+RH6tK3k9p0baWjh47p9SfHaMrcT5Q3X57UCobhHHtmlsxepvrN6zmPP37zMzVp10jBTeve9DO84oNRk9TzsR5q2am59oXu18jHR6cp6zWwp5q3b6rwPQf16oBRaa7NyjONuxinzyd8qTGfva6ChXx1Lvqchj06QpPnfCxJijkXo+p1q+uxIf20euFafffpD3rnq/9l+ByzomK1Cjr+9wlJqbPZ9/fvIUnasTFUUyd8qXe/eUsderbT8w++qEefe1ie3p5aPmeFWnVqni7ESlJYSJgefLxXlvouV6Ws/li2QWUrldHpk1EK33NIxUsH3bDsRirXrKg/t+0hyAJ3GIIsAAB3mW2/b9dfB/7WsH4jJKUuIU64nOAsr1anapoQK0lN2jaSi4uL/IsUUt58edSodWpwLV+lnKJPnZEtxZbh0s1m7ZtKkooWLyrvvF46F31egSWLafuGHVr6y3IlJiRmuCT4ivjYeJ04clKtu7SUJJWuUEoly5XQob2HVLtBLUlSm3/KMjP761916sRpPTPqSee5W31XOO5inCJPnFKLjqkzjlXrVFGJssXTlDX/5/4r1ajoLLsiK890364Dio6I0phn/z+oG4ah0xFR8vL2Ut58eZwzxZVqVNT3k3+8pXsyZTp/Dg87pF+n/6b4uHgZhqGoiGhJkk9BH93T+B6tW/qH2nRtpZXzV1/3HxLOnTkv30K+Wer78WED9dX73+iFPi+rcGBh1axXXa5ubjcsu5GChQrq4N5DWaoLwDoIsgAA3EHmhUZo4vJwRcYkKNDXW0/V9U9XxzSl9j3bqc/g3hm0IHnn8Up3zt3j/2fbXFxc5OHh7vxZ0nXfpb1S70pdh92u0ydPa/pH3+mD799VkcDCCtuxV5+MnXL9m8rw1cb/P+mVwXivNv+HRdq8eov+98UYeXp5Zlo3I66urjJNh/M4JSl1+bD5T+bLKMCbpmRkPHCnrDxT0zRVtnJZvTVtbLrrI4+fkrtn2jbsdke6ejfj8L6/1K5HGyUlJmniiA814ZvxKlupjM6cOqMnuj3jrNe1byd9PGay8uTNozIVS193Ay0PDw+lJCdLWXjn1tevgIa9/aLz+I1nxqlEmaAblt1IcnJyhrPFAKyNz+8AAHCHmBcaoZFz9ygiJkGmpIiYBL23LFzJtrThpn6LYK1ZtE7nzpyXlLrb8OF9f+XYOC/FX5aHp7v8/AvK4XBo+dyVzrI8+fIoKSHR+a5jPp98KlG6uNYt/l2SdPyv4zr+1wlVqFY+S30tmb1Maxau1dgpbyhf/rz/arxFixfRob2pz+fooWM6eviYJMnHN7+CSgbqj382GTqwO1wn/j7pLCtavIg2rNgoSTq097Cz7GZUrVVZJ46cVNiOvc5zB8NuPLt47XO8kZTkFP3w+U+6eP6imndopuSkZDkcDvkXSf2HkCW/LEtTv2ylMvL29tL0Sd+qU+8O1223VPmSijgamaUxxMbEyW5LHW/o5l06eTTCOaOfWdmNnDwSoTIVS2epLgDrYEYWAIA7xMTl4UpISRtcEm12JSSnPVezXg31Gdxb44a8LdPhkN1mV9N7m6h81XI5Ms5ylcuqfot6eub+IQooGqBq91RR+J7UcObrV0CN2zTS8w+8KB9fH034ZryGvfOiprz1hX6buUAuri56+e2h8vHN7ww21xMfG68v3v1KhQMDNPqpMZIkTy9PvTfjbUmZvyObusFR6gxprwE99d6ID7R9fYjKVCydJhS9NP4FfTzmM/327XxVqFY+TcB+afwL+nTsFP06Y54qVCuvUuVL/v97vVnkU9BHoz58VTM+nqlLcZdkt9lVJKiI3vjktUyvy+g5XuvKZlB2u112u13V6lTVu9Pfcu5Y/OATD+ilh4croFiA6jSqne76dve10axps3VP4+t/aqhR6wbauXmXqtapIin1/ewPX/9Yly+lLmVft+QPDR37vGo1qKnwP8P11QfT5eLqogIFC2j0pJHOmdTMyjJr0zRN/bk9TH2fevBGjxqAxRimad64Vi4IDg42Q0JCcnsYAABYRpkRi5XRn+qGpCMTOuf0cCwrMSFRj3d+Wh/9OFEBRdMvzc6qhMsJ8vL2kmEYOnromEY/PVZTf/tUef/lzPDtZtKbn6pMhdLq/kjX69aJj7ukkYNe1wcz382V5b3b1+/QplWb/7NvJwP/NcMwdpimGXzjmncfZmQBALhDBPp6KyImIcPzyJr1yzfqxy9mqetDnW8pxErS3p379N2nP8g0TRmGoSFvPHNHhNgzp89q9FNjVKiwn54eOTjTuvny59WAoY8qOjJaxcsUz7TufyHxcqIeff7hHO8XwH+PGVkAAO4QV96RvXp5sbe7q97pWUM96mRtYxwAwO2DGdnrY0YWAIA7xJWwevWuxcPbVyLEAgDuOARZAADuID3qBBFcAQB3vGz5/I5hGB0Mwwg3DOOwYRgjMigvaRjGWsMwQg3D+NMwjE7Z0S8AAAAA4O5zy0HWMAxXSZMldZRUVVJfwzCqXlPtdUmzTdOsI6mPpEy+eg4AAAAAwPVlx4xsfUmHTdP82zTNZEmzJHW/po4pyeefnwtIytqXsQEAAJDtFi7cr3vv/Urt2n2p5s2n6tln5+X2kLLk9Ok4des2Qw5H6mal48atUsOGnyko6C0dOBCdpu6qVYfUvv1XatNmmu6/f6aOH4/JUlliok0jRixVkyZT1KbNNL3yymJJUlKSTR07fq3Y2MQcuFMAN5Id78gGSTpx1fFJSQ2uqTNG0grDMJ6XlFdS22zoFwAAADcpKipOr722TMuWDVJQkI9M09TevVE31YbN5pCbW7a8oXZTJk3aoIED68nFxZAkdehQSYMG1VfPnt+lqRcTk6ChQxdq/vzHVK5cIf366x6NHLlUP/zQN9MySXrrrdXy9HTThg1PyzAMnTkTL0ny9HRTz541NG3aVg0b1iJnbxxAOtkRZI0Mzl37TZ++kmaYpvmBYRiNJM00DKO6aZqONA0ZxmBJgyWpZMmS2TA0AAAAXO3MmUtyd3eRn1/q94UNw1D16kWd5SEhJzV+/GrFxydLkkaPbqMWLcqqQYPP1KdPLW3ceEylSvnqgw+6aPbsP/XddztkszmUP7+n3nmno8qXL6T9+6P12mvLdPlyspKS7Hr44Tp64on6kqShQxfKw8NVR46c17FjF9SxY2W1a1dBH3zwhyIjY/XEE/X1+OP10407MdGmRYv2a8yYds5z9euXyPAejx69oICAvCpXrpAkqXXr8hoyZIHOn7+s48djrlvm6emmOXP2KCRkiAwj9a+4AQH5nO326FFVHTp8Q5AFbgPZEWRPSrr6d5HiSr90eJCkDpJkmuZmwzC8JPlLSrMGxDTNaZKmSanfkc2GsQEAAOAqVasWUe3agapX71M1alRK9euX0P33V5efXx5duJCgxx+foy+/7KV69YrLbncoLi7JeW10dLzmzHlEkrR163EtXLhPv/7aT56eblqz5rBefnmR5s9/TCVKFNCsWQ/J09NNly4lq3Pn6WrZsqwqVPCXJB08eEY///ywHA5TDRp8pri4RP36az9FRcWpefOp6tu3tvLm9Ugz7t27I1W6dEF5ed34r69ly/opOvqSdu2KVO3agfrttzBJUkTExUzLXFxcVLCgtz78cL02bTqqvHk99MorLZ2BOSAgnzw8XHX48FmVL+9/678YAP617Aiy2yVVMAyjjKQIpW7m9NA1dY5LaiNphmEYVSR5STqTDX0DAADgJri4GPrmmwd04EC0tmw5rmXLDmrq1M1atWqwduw4qQoV/FWvXnFJkquri3x9vZ3X9upV0/nzypWHtG9ftLp0mS5JMk3p4sXU90cTElI0cuQy7dsXJcMwFBUVp337opxBtkOHSvL0TP1raLlyhdS6dXm5uBgqVsxHBQp46dSp2HRB8dSpOAUE5M3SPfr4eOnzz+/TmDErlZRkU6tW5VSggJfc3FwzLUtJsevYsRhVr15Eo0e30c6dEerff7Y2bnxG+fN7SpICAvIqMjKOIAvkslsOsqZp2gzDeE7Sckmukr4xTXOvYRjjJIWYprlA0suSvjQM40WlLjvub5omM64AAAA5ZF5ohCYuD1dkTIICfb01vH0l9e8frP79g9Wy5RfavPmY3N1dM20jb15358+mKfXpU0vDh6dfZjthwjoFBOTV8uWPy83NRX37/qjERJuz3NPz//txdTWcoTb12EU2W5q3zyRJXl5uSkqyZ/l+mzcvo+bNy0iSzpyJ19SpW1SqlG+mZYmJNrm5uahHj2qSpHvuCZKfXx79/fc51aoVKCl10ydv7+yYCwJwK7LlLX3TNJeYplnRNM1ypmm+9c+5N/4JsTJNc59pmk1M06xlmmZt0zRXZEe/AAAAuLF5oREaOXePImIS5LicrBOHzmrk3D2aFxqhyMhYnTt3WSVL+io4uLgOHTqrkJCTkiS73aGYmIQM22zXroLmzNmjyMhYZ90//zwlSYqNTVRgoI/c3Fx04EC0tm07kWEbN6Ny5cL6669zWa4fHZ26SZPDYWrChHV65JF7lCePR6Zlfn551LhxKf3xxxFJ0l9/ndPZs5dUurSf8x6PH49RpUoBt3w/AG4N/5wEAABwh5u4PFwJKf/MZjokx+7Tit10XEMX7Ff5gHx65ZUWzg2fvvyyl8aOXaWEhBQZhjR6dFvn7OXVGjYsqVdfbakBA2a1WC+VAAAgAElEQVTLbjeVkmJXly5VVLNmMb3wQlMNGbJAc+eGqVSpgmrQ4NY38SxduqB8fDx1+PA5lS+fulHT6NHLtWRJuM6ciVefPj+qYEFvrV37pCTpvffWafv2k0pJsat587J67bXWzrYyK5swoaNefnmRxo1bJTc3F33ySTcVKOAlSdq+/aTq1AmSj4/XLd8PgFtj3K4rfIODg82QkJDcHgYAAIDllRmxON0nJaTUT08cmdA5p4fzr82bt1c7d0Zo3Lh7c6X/Z5+dpwcfrJVhsAf+C4Zh7DBNMzi3x3E7yvkPgAEAACBHBV61YVNWzt+uevSopjJlCsrhyPmJmKQkmxo0KEGIBW4TBFkAAIA73PD2leR9zUZO3u6uGt6+Ui6N6N8bMKCeXFyMHO/X09NNjz5aN8f7BZAx3pEFAAC4w/WoEyRJ6XYtvnIeAKyGIAsAAHAX6FEniOAK4I7B0mIAAAAAgKUQZAEAAAAAlkKQBQAAAABYCkEWAAAAAGApBFkAAAAAgKUQZAEAAAAAlkKQBQAAAABYCkEWAAAAAGApBFkAAAAAgKUQZAEAAAAAlkKQBQAAAABYCkEWAAAAAGApBFkAAAAAgKUQZAEAAAAAluKW2wNA7inzxRvycnOXp6ub7KZDoxq2V58qwZleM2bjYsUnJ+n9Vj1vqq9WsybpeOwF+Xh4SZIq+RXRrG4DNXXXeiXYUvRicOvrXnv04jmtOLpfg2s1dZ7rPGeKPmnzgMoVDLipcWRmV9RJjdm0WPPue1KS9MiiGVp7/KBOXYpV7AsfKJ+Hp7Pu9D2bNSlkreymQ2V9/TWjYz/5eee9YdkVA5d+rxlhW5zthp2J1Ku/z9PiXs9k2/0AAAAAdyqC7F3ul26DVD0gUKFRJ9Tkxw/VtlRl+efJ95/09XGbXupSrkaac0/VbnbD645ePKcvd29ME2T/i8D32voFGt2og/N4YI1G+rDV/So6ZWSaevvPndboDYsU+tgIBeTJr/Gbl+m19Qs09d6+mZZdsfDwHhmGkabN6gGB8nB109rjB9WqZMVsvzcAAADgTsLSYkiS6hQpofwenjpy8ZzGbFysYWvnOsuuPb5iRtgW3Tv7U/Wa96Vqz3hHbX7+RBFxMTfV77Vtv7NluWpOf0u1Z7yjJj98IIfp0HOrZmvfudOqM+MdPTD/K0mps8lhZyIlSYcvnFHbnz9Rrelvq+63E7TsyD5ney4Tn9PbW5ar/sz3VG7am/o1PDTDcRyPPa/w81FqFFTWea51qUoqnDd/urphZyNVu3BxBeRJLetUtpp+3BdywzJJOpcQr3GblujDDGa0+1Spq6//3JS1BwcAAADcxZiRhSRp7fGDSrTZVOEml+puiPhboY+NUCW/Ihq7cYmGrpmjX7o/nmHdF1bP0ej1iyRJQ+q21IAajdKUfxu2RQsP79GGh16Sj6e3ziXEy8Vw0Wdte2v4ut+0/dFXM2z3kcUz9ETNJhpUs7H2nT2lFrMmad/A151h0sfDS9v6vaKNJ//Sgwu/0f2V6qRr4/cTh1W/WKks3XOtgCCFnD6uIzFnVbpAIf24b7viU5J0PuFSpmV+3nn13KrZerNJJxXw9E7XbqPAMhq6ek6WxgAAAADczQiyd7kHFnwtL1c3+Xh6aU73QfL1ynNT1zcNKqtKfkUkSY/XbKyaM96+bt2MlhZfbfFfe/VU7Wby+SfkFfK+8RLnuORE7YqO0IAaDSVJVf2LqXZAcW2JPKqu5VP76lO5riSpYWAZRcZfVKItRV5u7mnaORl3QYXz+NywP0mq6FdEk1rfrz4Lp8swpO7la0qS3FxcMi37JXynPFzcrvsMiub1UdTlOKXY7XJ3dc3SWAAAAIC7EUH2LjMvNEITl4crMiZBp/0SNaFRT73QrHaaOm4urnKYpvM40WbLUtumTBk3rpbp9Td9jZnxNVe/gnoltLq6pK6ktzkc6ep7u3ko0ZaS5X77VAl2boy17dRRTQld7wzg1ytbe/yQ1hw/qDJfvOFsp/r08Vpy/zOq6l9MibYUubu4EmIBAACAG+Ad2bvIvNAIjZy7RxExCTIl2RymPl51UPNCI9LUK+frr51RJ+QwHYpLTtTiv8Ou2+bGiL916EK0JGlG2NZb2qioS7nqmrprveKSEyWlvk8qST6e3rqYlJjhNT6e3qpdOEjfhm2VJB04d1q7z0SoQbHSN9V3jYBAHbwQleX6p+NjJUmJthSN2bhEL9drc8OyKe0e1Imnx+vIk+N05MlxkqSwAa+rqn8xSdL+c1GqGRB4U+MGAAAA7kbMyN5FJi4PV0KKPc25RJtDE5eHq0edIOe5+yvW1i8Hdqr6N2+pfMEA1S1S4rpttihRQWM2Ltbes6dVyDuvvuv06L8e36PVGigi/qIaff++3Fxcld/DU7/3HaqaAYGq5FdYNaa/pcp+RdK9g/t95/56asVPmhSyVm4uLvqu86PO92OzqmlQWR25eE4XkxKc76/eP+9LbTt1TJJU+etxqu5fTMseeE6SNHDZ9zoWe17JdpserFxXQ+q2cLaVWVlmlh/dr54Va9+4IgAAAHCXM663NDO3BQcHmyEhITeuiCwrM2Jxhot3DUlHJnS+6fZmhG3R4r/Crru5k9W8s2W5vNzcM/2m7X8l2W5Tg5kTtbL38//Z548AAABgLYZh7DBNMzi3x3E7YmnxXSTQN/1OuZmdv9u8FNxa3tdsApVTjsWe11vNuxFiAQAAgCxgRvYucuUd2auXF3u7u+qdnjXSLC0GAAAAkPuYkb0+3pG9i1wJq1d2LQ709dbw9pUIsQAAAAAshSB7l+lRJ4jgCgAAAMDSeEcWAAAAAGApBFkAAAAAgKUQZAEAAAAAlkKQBQAAAABYCkEWAAAAAGApBFkAAAAAgKUQZAEAAAAAlkKQBQAAAABYCkEWAAAAAGApBFkAAAAAgKUQZAEAAAAAlkKQBQAAAABYCkEWAAAAAGApBFkAAAAAgKUQZAEAAAAAlkKQBQAAAABYCkEWAAAAAGApBFkAAAAAgKUQZAEAAG5jrcsEq0OVJupWu5U6Vm2qX776/pba+3TMRL07bEyW6184d17d67RW9zqt1a5CA9XKW9p5/NGotzV3xiwNeWDQLY3piufuH6A/t4dKkjasWKee9e5Vda8S6cZ75nS0nu7xqLrWaqmOVZtq/vdzslQmSUtmz1fXmi3UpUZzda3ZQmejoiVJ770yTot+mpst9wHgv+eW2wMAAABA5j755StVrF5FB8P2q2fddmreqa2KBBbNkb4LFvLT/NA1kqSt6zbq3eFjNXf7Cmf53BmzsqWf3Vt3KOHSZdWsV0eSVKJsKY2f9oGW/7pIyYlJaepOePkNVa9bW5/P+07nz5xVz+B7Vb9FIxUrEZRp2Z6QXfps7Pv6dvWvCihaWHEXY+Xh6SFJenz4M+rbrJs6PdhDLi7M9QC3O/4vBQAAsIiK1avIp2ABRUWckiTZ7Xa9O2yMutRori41muvdYWNkt9slSXEXYzVy4AvqWrOFutVupXHPjUzXXviefepas4W2/b7plsYVHxunoX2eUOfqzdWnaRedOR3tLPvyvc/Uq0F73Ve3rZ7q9kiasqv9PG2muvTt6TwuVb6MqtapITe39PMuB3bvU7MOrSRJfgH+qly7mpbOXnDDshmTvtDAl59WQNHCkqT8BXzk6eXlrFuibCltXr3+lp4FgJxBkAUAALCIHRu3qaB/IVWuVU1SavjbvztMc3es0twdq7Rv1x79PG2mJOntF0crT948mr9rrRbsWqvnxgxL09bm1X9o2MNP66NZ01S/ReNbGtee7bv06sQxWhz2h8pXqajvP/1KkjT/+zk6fviIZm9eqt92rFLzjm01YdibGbax7fdNqtngniz1V61uTS2ZNU+maerEkWMK3RSiyGMnblj2176DOvH3MT3corvuq9tWU8Z/KNM0ne3Wbhiszav/uJVHASCHsLQYAADgNjfkgcdTg9lfR/XZ3Ony8EhdDrt59R+677E+zuOe/ftq1bwleujp/lq7aKXmhqxwLpP18y/kbG/DynVav3yNvl4+O1uWKN/TpJ6KlQiSJNVqWFebVv0uSVqzcLnCQnbpvrptJUl2m035Cvhk2Mbpk6fkXyQgS/2NeH+M3n7pDXWv01qBJYPUsHVTubm737DMbrMpfM8+TV8xW8nJKXq8Yx8FliyuHo/2liQFFA3Q9vVb/v2DAJBjCLIAAAC3mXmhEZq4PFyRMQnyupigF977QE890EJLf1mg4f2e1fLwTfIvUlimacow0l5rXHsiA2UqltOhveEKC9mlIt063PJ4ryzPlSRXV1fZbanLm03T1NOjXlSvgQ/dsA0vby8lXfMu7PX4Bfjr/ZlTnMdPdH5I5apUuGFZYKni6nB/V3l4esrD01NtunXQn9tCnUE2KTFJXlfdC4DbF0uLAQAAbiPzQiM0cu4eRcQkyJRkd5iatOqQ5oVGqOMD3dTk3paaNuFTSVLjti3027c/KyUlRSkpKZr33c9q1Ka5JKlVl3b6euJk59LZ82fPOfsIKlVC01fM1oevva0lP89znn+s7f36c9vObLuX1l3b68fPZ+jihRhJUnJSkg7s3pth3Yo1quhI+OEstXvh3HnZbDZJ0uY163Vwz351eajnDcu69O2pDSvXyTRNpaSkaMua9apcq6qz3b/2H3Iu2wZwe2NGFgAA4DYycXm4ElLsac4l2eyauDxcPeoE6eW3R6lncDs98erzenBwPx0/fET33dNGktT03lbq/cQjkqSRH47T2y+OVpcaLeTq5qr6zRvp9U/edrZZtHigZqyao0EdHlTC5QT1eLS3DuzepyLFA7PtXnr0e0AxZ8/pkZY9JEmmw6G+Tw/IMCzee18nbVi+Vg1aNpEkhWzYqpf6Pqn42DiZpqnFP8/TW199pGbtW+nPbaF664VRcnF1VUF/P01dMFPeefJIUqZlnfvcp7CQ3epUrZlcXFzU9N6W6jXo4dSxmaa2rFmvp157IdvuH8B/x7j6BffbSXBwsBkSEpLbwwDuePGxsRrUoaPuvb+nBr38svP8rC+mKTHhsvoPHaptv/+u/bt26bEXsvcP928++FCVa9VS47ZtdCQ8XNPefU9HwsN1T5MmeuW9d531Ei5f1rQJ7+pIeLjsNpva9OiuHv36SZJmfvqpQjdvdtaNOHpMjw55Xp379Mn0uqW//KLL8fG6f8CAbL0nALhVZUYsVkZ/OzMkHZnQ+T/rd+/OP/XjlOl666uP/rM+MhMfG6e+zbrqly1L5eXtneP9r1++Vgt+mKOJ303O8b6B6zEMY4dpmsG5PY7bEUuLgbvcH0uXqVKNGtqwfIVSUlIyrFO/RYtsD7Fno6L057ZtatSmtSSpgJ+fBrz0oga89FK6ur9Ony43d3d9NOsnTfx+pn5fslThe/ZIkvo9/7w+/PFHffjjj3pz8mQZhqHGbdve8Lp2992nVfPm63J8fLbeFwDcqkDfjEPc9c5nl2r31My1ECtJ+Xzya8T7Y3XyyPFc6T8+Nk7DJozOlb4B3DyCLHCXW71ggXoNGqhS5ctp++8Zf3JgzcKFeu+VV53Haxct0quP9dewR/rpjaeeVsTRo856Y599Tu+PHKkXevfWyIGDdOHs2eu22ahNG+emJH4BAapYvbrcPdzT1T168JDqNGoowzDk5e2tavfcoz+WLktX7/fFS1Szfn0V9Pe/4XVubm6q3bChNq5cmfWHBQA5YHj7SvJ2d01zztvdVcPbV8qlEeWcJu1aqHzV3LnPjg90y5YdnAHkDIIscBc7cvCg4mNjVaNePbXq2lVrFiy44TX7QkO1ceUqjf9ymt7/fqZ69HtEn437n7P88L596v/CC/p49myVKFtGS36enWE7e3fsUIXqWdtQo1yVytq0erVsNptiY2K0a/NmnTl1Kl29NQsXqk33blm+rmKNGvpz2/YsjQEAckqPOkF6p2cNBfl6y5AU5Outd3rWUI86Qbk9NAC4bbDZE3CXufqTDpWOrlDDus1kGIYatmqlrye+r3PR0SpUuPB1rw/5Y72OHjqkV/v3lySZpnQpNtZZXrlWLfkXTf0X7YrVa2j31q0ZtnMuKlq+foUyLLtWz/799e3HH2t4v0dVoKCvqtWtq7iYmDR1DoXt1cULF1S3adMsX1fQv5DORUdnaQwAkJN61AkiuAJAJgiywF3kyicdElLsMhw2eRwL1Y4TYeq3ea3yeLjJZrNp7aLF6jXw+hsgmTLVpltX9X3qqQzL3T08nD+7uLrIbrdnWM/Dy1MpyVn7XqCnl5cGv/r/S5u/mDBBxcuUSVNn9YIFatGpo9zc3LJ8XXJSkjw8PbM0BgAAANw+WFoM3EWu/qRDgTMHlJjHX3uavaS/Ww3TFwsX6M3PPtXahQszbSO4WTOtW7xEZ6OiJEl2u11/7d9/02MpVa68Io4dy1Ldy/HxSkpMlCQdPXRIW9euU4cHejnLkxITtWHFCrXp1u2mrjt55KhKV6xw02MHAABA7mJGFriLRMYkOH8uFLlL54vVTHO+Us2acjgc2rtz53XbqHbPPXromaf1zksvy+FwyJaSosZt26hclSo3NZYGrVtp08pVat21qyQpOjJSrz3+hJITE5WclKTHO3VWn8GD1bZHd0VFROj9ka/J1dVV7h4eenH8/+QXEOBsa8vatQoqXVolypZN08eNrtu1ZYsefubpmxo3AAAAch/fkQXuIk0mrFHEVWH2iiBfb20c0TpHx2K32/XKo49p1MeT5PfPLsM56eTRo5r69tsaP21ajvcNAACQFXxH9vpYWgzcRW6nTzq4urrqqddGKjoiIsf7lqSzp6P05IgRudI3AAAAbg1Li4G7yJUdMK/sWhzo663h7Svl2s6YFapl7fM7/4XaDRvkWt8AAAC4NQRZ4C7DJx0AAABgdSwtBgAAAABYCkEWAAAAAGApBFkAAAAAgKUQZAEAAAAAlkKQBQAAAABYCkEWAAAAAGApBFkAAAAAgKUQZAEAAAAAlkKQBQAAAABYCkEWAAAAAGApBFkAAAAAgKUQZAEAAAAAlkKQBQAAAABYCkEWAAAAAGApBFkAAAAAgKUQZAEAAAAAlkKQBQAAAABYCkEWAAAAAGApBFkAAAAAgKUQZAEAAAAAluKW2wMAgDtVbNwltXtkmHp1aqHhT/Zxnp/6/QJdTkzSS48/oHVbdil07yG9OOiB/3w8DodDg16ZqAkjnlARfz8tXrNF385Zpr+Pn9KwJx9Un66tnXWPnjyttz/7XjGx8ZKklx7vrYb3VJUkHTt5Wv/7dKbiLl1WSopN9zarp6ce6ea89qcFqzV70Tq5ubrK1dVFsz57Q5L06jtfqG/3Nqpdtfx/fq8AAODORpAFgP/IknVbVbNKOS37fZuGDuwld/f0v+W2bFhbLRvWzpHxrFy/Q+VKBaqIv58kqVLZEnpnxGBNn700Xd03P5qhBzq1UJc2jXQsIkqDR7yveV+Ol7eXpyZ986vaNq2rPl1b63JCou5/6k01rVdD1SuV0eqNO7Vy/Q59P2mU8ubx0tnzF51tDnywk96bOktfvzc8R+4XAADcubIlyBqG0UHSx5JcJX1lmuaEDOr0ljRGkilpt2maD2VH3wBwu5q/YqOGDuqlb2Yv1bqtu9Wuad10dRas3Kg/tv2p90c9nXq8apN+WbROdodd+fJ467XnHlHp4kW1YOVGLV23TT758ujwsQjlz5tH7496Wv5+BbRr32G9+/lPcpgO2Wx2Pd6nszq2bJCur7nL/tATD3VxHpcvHSRJcnEx0tU9+PcJNQ6uLkkqFVREBfLn1caQMLVtWleGIcVfSpAkJSYlyzAM+fnmlyTNnLtCz/Trrrx5vCRJ/n4FnG1WKltCFy7G6lhElEoFFflXzxQAAEDKhiBrGIarpMmS2kk6KWm7YRgLTNPcd1WdCpJGSmpimuYFwzAK32q/AHA7C//7hC7GXVL9WpV17sJFzV+xIcMge7WdYQe1cn2Ivp44XB7u7tqwfY/GfDRDMz4YIUnae+ioZk9+U0UD/DTu4+80a+EaPffYfZoxZ5ke7tFWXdo0kmmazpB5tRSbTbv3/6XqFctkafxVypfSsrVb9VCPttp36JiOnozSqehzkqRhg/to6NhPNXvxOsXFX9bQgb0UWMRfkvT3iVPaE/63Js+cr5QUm3p1aq6eHZo7261ZuZy27dpPkAUAALckO2Zk60s6bJrm35JkGMYsSd0l7buqzhOSJpumeUGSTNOMzoZ+AeC2Mi80QhOXhysyJkH+Z/epcbVqMgxDrRvfo3c//0nRZy+osH/B617/x9Y/dfDvE+r34tuSJNOU4uIvO8trVymnogGpy4JrVC6jLaH7JUn1albWN7OX6lT0OTWsU1U1KpdN13ZMbLzc3dzk5emRpXsZ99IAvf/lz5q/aqPKlghUnWrl5ebmKkn6denv6ty6kR7r1V5nzsfoiVffV9UKpVSjclk57A6dPnNB0ye+opjYePUf9q5KBRVV3RoVJUmFCvoo+uyFLI0BAADgerIjyAZJOnHV8UlJ165pqyhJhmFsVOry4zGmaS7Lhr4B4LYwLzRCI+fuUUKKXXI4lBx1VL+fOaGWobuVx8NNNrtdC1dv0qAHO1+3DVOmut/bVM/0655huYeHu/NnVxcX2e12SdLDPdqqeYOa2hq6X+9O/UmN6lTVs4/dl+ZaLw8PJSWnZPl+ihcL0KQ3nnMe93zyDZUpUUyS9NOCNVr0TWrYDvDzVb1albUz7JBqVC6rooX91KFFfbm4uMjP10cN61TV3oNHnEE2KTlFvj75sjwOAACAjGTH53fSv1yV+h7s1dwkVZDUUlJfSV8ZhuGbriHDGGwYRohhGCFnzpzJhqEBQM6YuDw8NcRKco89JYdnPsVUaa+Ump20ZMYETRn/ouav3JRpG83r19Ki1ZsVdfa8JMlud2jfoWM37PvYydMqUaywenVqoYe6t1HYwaPp6uTPl0eFCvooMupslu7nfEysTDP1t/IFKzfKw91NDWpXkSQFFfHXxh1hkqRLlxMVuveQypUKlCR1bFlfm/4pS0hMUmjYIVUsU8LZ7pETp1WxTPEsjQEAAOB6smNG9qSkElcdF5cUmUGdLaZppkg6YhhGuFKD7farK5mmOU3SNEkKDg6+NgwDwG0rMub/30v1vHBMSQVLpDlfq0o5mQ5TO/YcvG4bdWtU1HOP9dDQsZNldzhks9nUtmmwqlYolWnfPy1Yo+1/HpC7m5s83N30f+zdd1xW5f/H8de5BzdTNirLAYgLFMSNe8/U0qzMfk2z/a38Nu1bNrRtllmmZcPce5u5caIoDhQQRQSVvec9fn/cegsCgmkZ9Xk+Hj4e3udc57quc27xwftc17nOKxPvq7Jcr84h7Dl0gnsG9wBgw/b9TJ+7lNz8QrbvO8oPizfw9fv/wc/Xk+37jjJv6UYUwLuhB59NfgpFMd+3fOfFh/nwmwX8vPw39HoDA3q0J7x9EAAPjOjHezN+5u4nza/cGdqns+W1PUXFJSScT6F9m+Y1XU4hhBBCiBtSrt5x/8MVKIoGiAX6AMmYw+n9JpPpRLkyA4H7TCbTQ4qiuAFRQFuTyZRRXb1hYWGmyMjIW+qbEEL8VbpO20pyduVFlrycbIh4tXcVR/z1ki+l8dqH3/HjZ69ZQulfaen6HVxOz+Lp8SP+8raFEEKIukhRlEMmkynsTvfj7+iWpxabTCY98AywCYgBFptMphOKokxRFGX4lWKbgAxFUU4C24BJNwqxQghR10waEIiNVl1hm41WzaQBgXeoR5V5NXDnwVH9SSv3bte/kkql4pExg+5I20IIIYT4Z7nlEdk/i4zICiHqmvKrFns62TBpQCAjQrzudLeEEEIIUUfJiGz1bsczskIIIYARIV4SXIUQQggh/gK3Y9ViIYQQQgghhBDiLyNBVgghhBBCCCFEnSJBVgghhBBCCCFEnSJBVgghhBBCCCFEnSJBVgghhBBCCCFEnSJBVgghhBBCCCFEnSJBVgghhBBCCCFEnSJBVgghhBBCCCFEnSJBVgghhBBCCCFEnSJBVgghhBBCCCFEnaK50x0QQvy9rfu1K2q1DpVGZ9nWtf9s7Bx8bkv9mWnRxB2bS8feX9xyXfEnfubMyV9QFAWjoZSGjfrQptMblJbkkBCzgOZtn6z22KKCy+zf+jw9hy0EYMnsxox8+AQard0t96u8c6eXcGTvFGwdvAFQUNGm0xt4eHX5Q/UV5CWxZflw7nooqtbHHN49mfTLkQDkZsVj7+Bj+X77jVzL0jl+t+Xck89t5vKF3YSGT8FgKCFi0+NkpR0DqNTfmKiZnI9fhcmox8WjLe26T0Wt1pXbtxJFUaPR2tOu2wc4ujQDICVxC9H7PsBoMuDs1pr2PT9Bo7EhJ/M00fun0m3QvFs6ByGEEEL8PUmQFULUqHO/WTi6BP4pdbu4B1cbYo1GPSpV7f6bykw9StyxufQZuQornSMmo4GcrFgAykpzOX3022qDrNGox8auviXE/tk8vMLp0m8WABfPb+NwxGQGjvn9L2kbIDT8Xcvf1/3a9U/7fo8f/NQSJBVFTWDwE+isndmxblyFcpcu7CTpzBr6jFiJWmPDoV2vEXdsLs3bPkV2+gkSYn5lwOjf0GhtiTv+A9H7P6DboHnoywqI3PkqvYYvwcGxCZE7XiH26GxatnseR5dAVCotqSl78PD8YzcJhBBCCPH3JUFWCPGHLZndmNZhL5OcuJnS4izadZ9GavJuLiXtwGjU07nv19Rz9ic1ZS9H9ryDs1trsjNiUFQaOvT8hHrOAaSm7CV63wf0HbXGMrro32o8l5MjaBQwgiaBYzh28BPSLu7HaCzF0bk57bq9V2m0sKjgIlorB8t2RaXGybUFAId3v0VZaS6blw1Co7Gh913L2b7mXlzrtyMz9QgqtY7Q8ClVjmyaTEaO7n2P4qI02gsSnN4AACAASURBVPf8BKOhlKN73yM78xRGQwnunp1o22kyikrNiUPTSYpfjUqjQ0Ghx9AFWOkcb3gNy0pzK5TZv/V58rITMBhKsXdsRPseH1v2nz21mLjj3wOgUlsRPmBuhboMhhIObHsRG7sGtOn0Joqi/IFv1Szu+DySz22itDiL4I6v4910EAAZqVEc2/8hZWX5ALQOe5GGvr0rHZ928QA6a2ds7Rua+6vSUN87nIK8pEplczJicGvQHo3WFoAGPj05Efk5zds+BYqC0ViGQV+ERmtLWWkeNnbmOi8mbcfFPRgHxyYANG35AAe3v0TLds8D4Os/nLOnFkmQFUIIIf6BJMgKIWq097eJlqmnKkVD31FrLPu0unr0HbmapIR1RGx6nM59vyKowyucOvINMVFf0bH3dAByMk8R0uVt3D07cS52KQe2vVihnqtKS7Ko5+xPq7D/AHDy8JdorRzoO3IVANH7pxIT9TVBHSZVOK6+d3dOHf2Gdb92xb1hRzw8O+EbMBKNxsYSUvvfvaHCMTmZsXQb/BMqlabKgGUwlHBg+8vYOXjTsfcMFEUhavdbuDfsSFiPDzGZjOzf+jxnTy/Gu+lgYqO/Y/iDh1BrrCkrzUetsa7yeqYm72bzskHoywopKcqk26DvLfvadvkfOmsXAI4f/IRTR2YR3PFVUlP2EnNkJr2HL8Ha1gN9WQGKosZQVGy+bsXZ7PltAl6NBxAQ9MgNvs3a0Wrt6TtyNemXItm75Wm8mw6itCSHw7veIHzQPGxsPSgqTOX3FcPpf8+mSoE97eI+XDza1qotZ7cgEk4tpKQ4E61VPS6cWUthfjIATq4taRb0GOsWhKO1qoeVrh49hy0GoDA/BVt7L0s9tvaeFOZftHx2rR9K1J53bvVSCCGEEOJvSIKsEKKSlVHJfLzpNCnZRbzZqBiX4GmM7NqtyrI+fkMBcHZrjaIoltE5Z/cgks9ttJSzr9cYd89OADQKGMWhna9TVppXqT6VWod306GWzymJW9CX5nHh7HoAjIZSnFxaVDpOo7Wl910ryEqLJv3SQRJOLSL+xE/0Hbm62vP09R9+w6nLu9Y/hI/fMALbPFGhP5lpRzl97DsADPpibOwaotXa4+DYlP1bX6CBTw8aNuqD1sq+ynrLTy1OTdnLvt+fZeC929BobEiMXU5i/EqMhjIM+kLsr4w2Xjy/jcYBo7C29bhyvtdGpA2GErauvodWYf/Bp+mQas/nZvj4DwPA1SOE4sLLGPTFZFw+TEFeErs2PFSupEJ+biIu7sEVji/Kv4iDk1+t2vLw6oJ/ywfZue5B1BodHp5dUSXvBqAg7wIpib8xeOwOrG09OH30Ww5uf4nwgd/XUCtY27hTUpSO0ViGSqWt3YkLIYQQok6QICuEqGBlVDKvLT9GUZkBAL3RxPTfY1FsmzIixKtS+asL8iiKCpXKyrJdUVSYjIabbl+jsb1uSqyJ0PD3arUYkqIouHi0wcWjDf6txrP653bkZMVWO723psWM3D07c+nCDvxajrNMezVhokv/2djX861UvveIFWRciiQ1ZQ9blg+l26AfLdObq+Ph2RmjUU9uZiwGQwlnTv5C77uWobNx5Xz8KhJifrVch+qo1FpcPUJIObcF78YDUVTqG7ZZG5bv9UpdJpMBMOHo0oJewxfXfLzGGoOhpNbtBQQ9YhlJTjqzFgcnfwAuJKzH0SXQEuAbBYzixCHzKL+tvSdpKXstdZhHaBtaPhsMJSgqrYRYIYQQ4h9IXr8jhKjg402nLSH2quIyIx9vOn1L9ebnniPt4gEAzsevwtElEK2VQ43HeTbqS+yxORj05im0ZaX55GbFVyqXmx1PTua1PublJGA0lGFj1wCt1gGDvgijUX9TfW7V7nnqe4Wza8NDltFjz0Z9OXVkliWklxRnUpCbRFlpPiXFmbh7dqJV2Is4OgeSe2WxqRvJyTyFvjQfOwdvykpz0Vo5YGXtjMFQwtnT1wKjp28fzsUtp7gwDQB9WYElKCqoCOvxEVore/b+/gxGYxkA8cd/5NiBD2/qnG/EtX478nPOkpqyx7ItM/UoJlPlkO3o0py8nIRa111cmApAaUkOp47MIrDN4wDYOfiQfikSfVkhABeTtuHobF6xuIF3DzLTosnLOQtAwsn5eJcbkc7NjsfJpflNnqUQQggh6gIZkRVCVJCSXVRp2/j6c9CbNGxe9jEAYd0/rDSVtCZOri1JOrOaI3unoChqOvT6rFbHNW87kROR09myYjiKYr731rLdC9Rz9q9QzqAv5sieKZQUpZsXW1LUdOg9HWsbNwB8A0aweekArHSO9L5rea373bztRNQaa3asG0f3QT/StvNbRO+fyuZlgwAFtdqKtl3eQlFp2PvbkxgMJZhMRpzdWuPVeECVdV59RpYrAbB9z0/Q2bjSwKcniXEr2Li4DzZ2DXBxCyYz7QgA7p6daNH2KXasG4eiKKjUOsIHzLHUqSgKoeHvcnTf+0RseoIu/WaRmx1/216TBGClc6TrgDlE7/+AI3umYDSWYefgS/jAuUDFhaUa+vYmJuorTCaj5XvbsmI4RfkXKS3NYe38TjTw7kFYD3PQ3rHuQcCI0ajHv9V4y7XzajKQzNQjbFk+FJXaCq2uHu17fgKA1sr8Kp7dGx/FZDLg7NqKtsH/s/ThctJOvJoMvG3nL4QQQoi/D6WqO+l/B2FhYabIyMg73Q0h/nW6TttKchVh1svJhohXK69OWxvlVyYWf51ta8YQPuD7ap/V/bMd2vkaDXx63JEwaTSUsmXlXfQYMt+yeJa4ddGJiWw7cQIToDcY8HJ25r7wcAB+i46mV6tWaNS3NrV95YEDnEtPByA1JwcXe3tLnc8NHIhKVfvJZJuOHMFoMjEoJOSm+vD+8uXotFpLuwENGjAkNJSNR47g6eJCsG/lRwuqU1hSwsEzZ+jRsmW1ZXILC1kfFUViejpWajUqlYougYG096vdc+ZV2RkTQ7smTbCzrnrRudo4fv48TnZ2eLu63rAdRVHo1rw5WQUFLN67l+SMDDwcHXlm4LWffYPRyNrDhzlz6RIGo5FW3t4MCglBUZQb7gNIzsxkdWQkhSXmWSjDwsJo1rAhJy9cIDYlhREdOvzhcxTi705RlEMmkynsTvfj70hGZIUQFUwaEFjhGVkAG62aSQP+nPfIij9Pr2E1P8v6Z2rd/mUuX1m06a9WkJ9MUPv/Soi9jXKLilh58CDPDRqEk50dJpOJi1lZlv1bjh2je4sWNx1kDUYj6nLhtHwombZyJeO6daOBk1Otjr2dxnfvjodjxefrB7ateiVuo9GIoihVvvKqsLSUnTEx1QbZkrIyvvntNzoGBHBvly4oikJhSQnHzp+/pf7viomhuafnrQXZpCQau7tXG2RL9Xr2xsby4lDzAn06jYb+wcEUlpSw7cSJCmUPxMeTmZfH84MHA/DDtm0cS0oi2Nf3hvtKysr4eedOHggPx8fNDYPRSEmZ+fGJlt7ebI6OJjM/Hxf7O3PDTghx50iQFUJUcHVBp6urFns62TBpQGCVCz3VlodnZxmN/RfS2bji63/XHWnbwbGJ5f2y4vbIKypCpVJhq7u6wJuCp4v5RsHKA+bn37/evBlFUZjQty+nkpOJOH0ag9EIwJDQUPwbNADMATXMz48zly/jYm/P6E6datUHg9HI6wsWMDgkhJjkZPzq16dvUBDbTpzgxIULGI1GnOzsuLtjR+yvC3ApmZks2rOHER060MTD4w9dg4URETR2d6dTs2ZsOnKE7MJCisvKyMjLY2L//qyPiuJsaioalQprrZYn+/dn5cGDFJaUMH39enQaDRP7969QZ9TZszjY2FQIurY6HR0DAgDzdV9+4ACZ+eZ3N/ds2ZKQJuZ/2+8vX057f39iU1LILy6mR8uWdG7WjC3HjlFQUsJPO3eiUat5IDycrIICfouORm8wYDQa6RMURHCjRgBkFxSwOjKSjCtthDRuTAMnJ06lpJCQmsq++Hh6tGhhafeqo4mJ+NWvj/bKzQtbnY4mHh7EXbzI9VKysvBv0MBy48G/QQOOnD1LsK/vDfcdPnsWv/r18XEzPyaiLvdvECDY15fIhAT6B9/c4y5CiLpPgqwQopIRIV63FFyFEP88DZ2d8XF1ZerKlTT18KCxhwehTZpgp9MxokMH9sbF8VT//ui05lWim3l60rZxYxRFIS03l9lbtvDGqFGW+vKKipjQt+8f6ouiKDzZrx8AkWfOkFNYyNMDBqBSFCJOn2bd4cPc2+XaSuexFy+y7vBhHujWzTLKOmfrVga3bWsJ49e7GgIBhoSEENCwYaUyZ1NTeXbQIOx0OpIyMjibmsqLQ4eiujKqCjCifXtmbd7MC1dGG6+XnJVlCWlVWXnwIJ7OzjzUowc5hYXM2LABTxcX6l85D4PBwDMDB5KRl8f09esJa9qUvkFB7I+LqzCqbKfTMbFfP1QqFblFRXy5YQPNPD2x1mpZEBFBax8fxvfoAUBBcTF21tY09/S0BPeqJFy+XOubAt4uLhw5d46OAQGYTCZOXrhAmcFQ477UnBwURWHu1q3kFRfj7eLCkNBQbKzMq+T7urnxW3Q0SJAV4l9HgqwQQgghqlX+vdKeTjY83SOIxi5w4sIFdp48yX+GDKkwQnZVZl4eC44eJaeoCLVKRX5xMXlFRTjY2AAQ2rTpH+5Tu3IjgyeTk7mYlcWMDRsA8zTf8v05nZLCqZQUHuvd29I2wGO9b/zMf1VTi6/X3MsLuyttudrbYzAaWbZ/P37169PCq3Y3A2taqyTu0iVGtG8PgKOtLYGeniRcvmwJsm2ujKq6Ojig02jIKSrCzaHyivD5xcUs2bePjLw8VCoVhaWlpOfm4urgwIXMTCZcuTEA1Ho6ck5hYaWR7+q09/MjMz+frzdvxlqrxcfNjcS0tBr3GU0mzly+zFP9+2Nnbc2ayEjWR0Vxd8eOADjY2JBTWFirPggh/lkkyAohhBCiSte/Vzo5u4h3159l6qggHu/Th0/XrCHh8mVaV7H40a8REQwNDaWVjw9Gk4nJCxdaRtnA/DzlH2WlLfduYJOJvkFBtKsmGLvVq8el7GwuZGbWOlzWVvlzsNXpeHHoUM5cukT8pUtsiIqyPPN5I1dHI29G+Sdxyz+TrCgKxitTua+3/MABgn19Gd+9O4qi8OGqVRW+jz9Cq1ajr2UdKpWKQSEhloW3th4/brlRcKN9TnZ2+DdoYLkJ0aZxY1YePGipV28w3PICY0KIukneIyuEEEKIKpV/r7SNxoirrZ6iMgMfbzpNdmEhBSUlOF9ZZEen0VB8ZREegOLSUsu+g2fOoK8mYN2qFt7e7I2Npai0FIAyg6HCIlSu9vY82rs36w8fJvoWF1C6kfziYvQGA829vBgcEoJWoyErPx9rrZZSvb7agBnSpAk5RUXsjImxjM4WlpQQceoUYF4xeX+8+d3ZuYWFxKak0LR+/Rr7Y63VVvl9KIrCqeRkyzO3NlZWeLu4EHH62nu4C4rN7+3WXVfH9Ro4OZGWm1tjXwDK9HrLd5SZn8/+uDjCmzevcV+bRo04n55uWeApNiWFhuUW/0rNyaGhs3Ot+iCE+GeREVkhhBBCVKn8e6UVBVp7FGNrZcRgzOWHbdvo36YNXleeMe3WogWzt2xBq9EwoW9fhrVrx087duBoa0sTD48qpx/fDu39/CgsKeGb334DzFN1uwQGVgg3znZ2PN6nD3O3bkWv1xPatGmNz8jerKyCApbv34/RZMJoMtHK2xtvV1cURSHI15fP1q0zP6d63WJPOq2WJ/v1Y31UFB+tXo2VWo1arabLledSR7Rvz7L9+/l83TrAvGhWTVOeAboGBrJozx60Gg0PhIczKCSEVQcPsvX4cTydnWlQro77unZl5cGDHIyPR6UohDRpQo+WLQlt2pSle/dyNDGR7lUs9hTk68uaQ4foExQEmEdHP1y1CoPRSHFZGe8vX06ngAD6BAVRVFrK7N9/N6/uDAxp1w7PK9/Rjfa52NsT3rw5X23ahEpRcLW3Z9SVacVgfv45yOf2vS9bCFF3yHtkhRBCCFGlP+O90uKf5bvff2doaOgdGRXNLy5mztatPDtw4J/2GiYh7jR5j2z15KdeCCGEEFWaNCAQG23F5w/lvdKivBHt25NbVPlmx18hMz+fkR06SIgV4l9KphYLIYQQokp/xnulxT+Le716uNerd0fa9r3Ba4uEEP98EmSFEEIIUS15r7QQQoi/I5mLIYQQQgghhBCiTpEgK4QQQgghhBCiTpEgK4QQQgghhBCiTpEgK4QQQgghhBCiTpEgK4QQQgghhBCiTpEgK4QQQgghhBCiTpEgK4QQQgghhBCiTpEgK4QQQgghhBCiTpEgK4QQ4k83s8uzzGg3gc+DH+UN6wHMaDeBGe0msPTRj2+57oNz17PggfdvQy/N4n8/zGvafmx8Y26F7d/0eIHXtP0oKy79w3WnxyfzvveYW+3iTTMajczq9jy5FzMAOPTTZqa3fZw3rAew/9s1FcqmnjrPd31f5ovQCXwROoH4rYdrtW/R+GlMa3K/5bvd/tFCAEwmE9/2/A9ZiZf/gjMVQgjxb6G50x0QQgjxz/f0ni8ByDp3ia86Pc1zh769wz26MY8WvhxfsYv+7z6MSqUiPe4C+pKyO92tP+zowm14tvWjXkNXALxCArh/wZts/WB+pbJLHv6Irs+Pou3Y3qSeOs/3g17lpZh5aK2tbrgPoNer99FxwrAK9SmKQpdnR7L1vV+4+7uX/vyTFUII8a8gI7JCCCHuqPljp3Bi5W4Atk37lSkeozAajQB80vL/yEy4CEDkDxuZ2fkZvmw/kTn9J5Eed6FSXbN7v8ip9fstn0+s3M3cga8AkJOczi9j3mFm52eY3vZxdnyyqNo+6Rxs8W7XjPjfzSOOh37aTOiD/SqUOb8/hq+7PssXIU8wq9vzJB+OA66Num58fQ4zwp7ks9aPkLjnRKU2yopLmX/vFDa8+h0mk6na/h1ZsJWf7/5fhePe9x5Dbko653YfZ0bYk8xoN4HpbR8nesmOKs/n4Jx1tBnb2/K5QVATPFo0QlEq/xpw6VgCgQPaA+DR3Bedgw1xmyNr3HcjLYZ1JmbtXkoLi2ssK4QQQtSGBFkhbtKRLef5dNxGPnlgI9NGr+PnN/dY9m2cfQx9meGW24g9cIlpY9ZbPhfll/Jy50XsXhJn2bbtl1PM/9/eW26rOqXFej4bv4mSIr2lvan3rOOljgs5sSu5Qtlzx9L54pHf+Pj+DXz+0GYunMoEQF9m4JMHNrL8na4sfbsniyf3YeHr3Ynbu8Cy7+qfqXev4+XOiyjIKQFg5pO/E7XuU5JPbqiyf6d3fcWJ3z/6087/Ri7GbmHb7KHs+H4U+RlnK+xLTzxAakKE5XNhdjIbp3e55Taj1r7O2cjKo2c3q6w4l/h9c2ssdzl+B2umtuRi7JYblruZ89OXFbF/yVOACYAz+79n67eDKSxdw7EVa83btkbhHujDqU3r+e3zMRRmpnB8x/NEr1jFydURTNjxOeNWPolTq3i+v+sxtn03jPTzBy1t+ITbsvHtyayZ2orLcds59NNm2j00AIDvBj5E+8e68/Ter3jmwNecXLWHM9uPVNvf0PH9OfzTbxiNRo4t20mbe3tZ9l0NoQM/eIzno2bTZ/I45t87BUOZ+ecl/3IWTXq04bnIb+jx37FserPiNS/IyOX7Qa/StEcbBk17HEVRWPzQNLq9cE+l/gXd053kw3Fkn08F4OjCrTQOb009Tze2f7SA7i+P4blD3/J81GwC+rWrfN1LSkk6eBrvsGa1+p48QwI4smArAEkHTpERn2KZFnyjfQA7P1vC9LaP88vot0k7nWTZrrHS4t7cl/N7T9aqD0IIIURNZGqxEDchN72IZR8d4sWf++Nc3w6TyURKXLZl/+Y5J+g1rjkarfqm6jXojag11+4rNQ52IyM5n7yMYhxcrTl7JB3vFi6cOZRK+OgAAM4cSiWol/cttXMjuxbFEdzbB52N+b8Jv1B3WvfwYvH7ByqUM5lMzHs1ggff7YxfqAcJR9L45a19vLJoEBqtmpfnD2TL15/QYfQsorYYSTh0mNM7p+LTug8vzx9oqWfHgtPEHbiMnaMOgO5jAzm23Y6QIZ1u6hxvxGjUo1Ld+n97iVGLCez2DJ4tBlbal3H+APrSQjyadr3ldv4MZcV5xO+bi3+nR29YLil6BW6NOpJ0dAUNm/WtsozRqL+pts9FzsejaTfAPPrq6tOeBgF90Oe/zpFvz1FWXEp+ajZdnh1JxLefENB9DK2GF9Cqb0+WPPYGWaed+brzM+RnnkNn5wZ6ezrf9xm/PnoXVpj72O7BERz89gQOrqEUZhZwfu9J7pv/BsW5BWTF61n59OfY1DM/u1mSX0RqzHn8eratsr/+fUJZ88JMTq6MwCskAGsne8u+tJjz6OxtaNqjDQDN+rfHZDKREZ+MSqvB2tHOMnLp27EFm9/6wXJsWWEJ3/Z4gQHvPUKrEeEAFOcWcC7iOKuenWEpV75/7R8dxP7v1jLg3UfYN2s1gz+aAEDTnm3ZNvVXss5exL9PO3w6NK90Hvmp2WhtdWh0VrX6nkb/8F/WT/qGg3PXU79VE3w7t0St1dS4b+DUx3Bo6IJKpSLyh438MOx1Jp3+CUVRAHBo4EzOhbRa9UEIIYSoiQRZIW5CbkYxao1iCVuKouDVzBmAZR+Zp9fNeGwLiqLw9De9ORmRwq5FsRjKzNMkhz3XlmYdGgDw7l2r6Ti8KXGRqbh62jF2ckdLO1bWGnxbuhB/OJWQfr6cOZxKtzEBbP7OPD3RaDCScDSNkS+HArD6iyjOHE5DX2bE3smKeyd3xKWhHZkp+Xz+0Ga6jg4g7uBl2g1sTD03a9Z/cwyVSsFoMDFqUij+7epXOtd9K+OZ+PW1qYi+LV2rvCYF2SUU55XiF+oBQNO27uSkFXLhVBY+LVwqlD2w5iwDHg/nYrQjxXmXsXbwIDc1lmObppAadxnvRmoSDpyjaYfxtAz3JHLFK8TuiaVZl/GUFedxdP1k8tLjsanniZWtMzo71yvXo5RTO74g43wkRkMpDu7NCB74FhorO6LWvo7GypaCzPOUFmXSZdzPHFn7Gnlp8ajUWuxcGhM28vPK55WZSPTGtykpzEJRqWnR4wU8/LpxfMs0MpMOUZB5jnOHF9LlgXnX/n2kxpIYtQiTyUT6ub14thyMV4vBAMTsmE7qmZ0YyoppM/hdXH3MI2eX43cQt2c2RkMJKpWWVn1fxdmrTZXXuiolBelEb3yHgqwkwIRfx0fwCboLk8nIsU3vkZ64H7XGCrXWlvDx8zm2+V30xXnsmDsStdaG8PG/VqqztDCb9MR99HpiLdtmD6M4Pw1re3cA9sx/CGevtmSnRKPS6AjqP9lynEFfStSaV7BxaEDLPv9FURRWRiXz8abTpGQX8Y7jT+iavcXVIOvkGQSAfQMN+qJiohdto1GXVvh2acq2T4xcrpdN4KAOuPq0Q19SQPC9/Rjy4Uvs+H4Ufh3G4t16GPmZ51BpdChG880jj4Awmg/uTMr+AxSdP06rEeFobXToS8pQVCqCJ2bS7+kFaHR2NV5blUpF65HhrHhqOmN+fLXCPpPJBEoVB10JbRrra6FRUasw6q/N1NBYW+HdvjknV++hxbDOqNRqTEYTikrF0/u/Rq2pfCOsw+NDmdn5aZoNaE9ZcaklQHd/cTQth3fhzO+HWfXsDJoP6UTft8ZXOFZro0NfXPvne938vRi/4l3L509bPYxHC98a9zl6uVm2hz08kLUvzyI3JcOyXV9citZGV+t+CCGEEDciQVaIm+AZ4IRvS1feHbYav3YeNGnjTtigxtg56bj7v2FELI3nuTl90dlqAWjeqSGhAxqhKAqpibnMenob/1t7l6W+3PRinp7Vu8q2/Nt5cObQlSAblUqP+wM5vCmRS2dyKCsxYGOvxdXLPELU+6GWDH/e/AvivpVnWPvVUca/b57uWZBTSv0mjgx8whwaPr5/I/f8tx1NQzwwGoyUFlWeCp11uYDSIgMuDWv+Zd/e2Ro7Jx3Hd1ygdQ9vTuxKpqRAT9alggpB9tKZHPIyimjY5DIZ8U7Uqx8IgK2jF95tP2HTL3t5Y0U/9vwyFvemXXFw88PG3oqM5AIAYiO+RqOzo9cTaykpzGLnD3fj2dw8Ihq/73s0Oge6/Z/5mcKT2z4lbu93tOjxgvl8ko/S5YEf0VjZcvH0FsqKc+n1hHkqa2lRTpXndXj1f2kUMgbfNneTlx5PxC/j6fXEWlr3fZXcyzH4dXiY+gE9KxxTz6MZjULuRV9aSKs+/wXMU2/LirJx8WxLix4vcOH4GmK2fUb4+PkUZJ0nLuIbOo79Dq3Onry0OPYtnkC/p7fWeN2vOv7bBzi4BdD+7i8pzk9j5/d349igJSZDGenn9tJrwjoURWU5z6D+k9k5bzQ9Hl1RbZ0Xjq+mvn9PdHZuNAzsx4XjqyuM4OalxdNx7HeoVBoKs5OvXMdsIpc/T4NmfWna/kEAVkYl89ryYxSVGXBSslEbi/loewaD9cZKbXp3asyWd39m8IdP0KBFc8ryNcRu3sfgj57gUtw2nALyiF68j27Pp9N2yPscWPwM+3/5HBu3HLxa3U/6iWvPXrZ7qD9LJ2znojaa0XPeAMDGyR7fji1IPZhI5oXDePh1IyvxMhprKxzqO1d7LTpOGIaNswMBfUMxma5t92jZiJK8Is7uiqZJt2DithxCURRc/TxrXJ1XUSmM/n4SK5/+goUPTuXeH1+90r/m7Pp0MT1fuQ+gQv8c6jvTpFswix6cSo//jrXUlXY6CfdAH9z8vdDY6Ihesr1Se3Zujlg72pJzIQ1Hb/cb9g0gPzULO3cnFEXh4Nz16OxtaNI9uMZ9OcnpltB6asN+tDY6HBpcu7apDjse9QAAIABJREFUp87TILhpje0LIYQQtSFBVohaKD+q5Olmw1PPt6ZRkcLxHRfY9sspJv060DJKW156cj4bJkeTk1qEWqMiL6OY3PQi6rnZABA2uHG1bfq3q8+yjw9RXFBGSaGeem42+IV4EH84lbISg2UEFODUnhR2L42ntFCP0VAxJGh0atr29bF8DgjzYNUXR2jTx4cWXRrS0M+pUts5l4uwd7Gu9fV5+KNw1nx5lE1zTtCotSv1m9SrNIU5ZtsrhPWC/QtTCbt7Biq1ecTKoC8iau2bhPU6z74FP1Gcn0Zu6mkc3PzQ6tQU55lfdZKeeICg/uZQorN1pmGzawvvXI7bRllJPhdPbQLAaCijnkegZX/D5v3RWNkCUM8jkPyMsxzb9C6uvu3x8O9R6Xz0JQXkpp7CJ3gkAA5u/jjWb05W8lEaBPSqVL4maitbS+h19mrDya3mZ3vTEiIoyE5izy8PWsqajAZKCtLNU2drIe3sXlr2Nodma3t36vv3ICNxP96tzaOyR9e9iWujTtSv4jyrk3RsBa36mBdI8gkewZF1kysEWa9WQypM0TbqS4j4eVyl6dYfbzpN0ZVnxp1U2eSZHCjWGyzbyvPt1JhTq47R9Mo0X//eXUjYcZDD6x/H2bMNXh188Arsxrzhb1KYnYxK7UbouKF0ejicZc8/iqr02nO6TXu0oTTPiOJgwLdTS8v2sfPf4OexT/LjkK/QWv+EdT1b7pk76YZB1snHg+4vmV+XYyg3qqq1tuKBRW+x9sWvKSsswcrehgcWTrZMs62JoiiM/PoF1rz4NfPHvMP9Cyczdv4brH1pFtPbPg5QqX/tHx1EzJq9hI67NtU7YsZyzu4+hlqrQaPTcteMZ6tsr9VdXYndHEn7RwYBEDV/CxvfmEtRVj6nNuxn69RfeWzTR7gH+nBiZQS7pi8Fkwm3AG/GLXnbMj34RvsWPzSNgvQcFJUKa0c7xi+fgkptHl3OOJOCRmeFR3PfWl0fIYQQoiYSZIWoQflRJYDk7CLe25/A1FFBPDm6Fx/eu54zh1MJ7uVT6dhf3tzD8OdDCOrpjdFo4tXuS9CXXvtlWGdb/Y9g42A3MlPyid6WRJM25lDTNMSdHfNPU1ZiILiP+fnYzIsFrPo8ihfm9cfVy56z0en8MvnaAlQ6a7XlF02AES+GkhKfTXzkZX58bQ897g+k8wi/Cm1rrdUV+lkT7+YuTJxpDnj6MgP/G7iS6MIinpi2lZTsIt6tV0z8nvuY8MUDmEr3EbXmFXpPWI/Ozo0Tv3/O5USFYS/9imeAG3sXPIZRb17wyWg0odZeDcSmalo3T/MMHjAZt8ZVP0+r0dpa/m7n7EOvx9eSlriX1DO7OLVjOj0eW4Vac+1GhKmatpQq55LW7GpoB1AUNUajwdKOR9NwQoZN+0P1lqv0+g1orR3o+fhqMhIPkJ64j5jtn9L94aU1VpV98Th56Wc4sv5Ny7bivFQyL0Th4h0CVLyeACq1FmevNlyK20bDwH4oKnN4SckuspQpM2nRoKfA0ZFlEyfwyXXtthgeRM+XroWwsT9OsfzdaChl84zudHvkLro89SBbZvZhyKRr7y8NHOaPb3B4ucuh0Ofj+vh1eLhCG/UautLhuYY0DOyHd+uKr4gpz79PKP59QittV2vUTC37zfLZt2MLnor4slI5N38v3riwuMrP1+8b9tlTFfp3/6/Xrvv1ErYfpd1D/dE5XLv+I2Y+X2358sJfuIfF//ehJciGPNCXkAeqfva54xND6fjE0Jve9/iW67/Va/bPXku3F0fXqq9CCCFEbciqxULUoPyoknWJEZcc84jSx5tOk325kPysElw8zVN8dXYaivKvPYtWlFeGi6d5eu7+1QnoSytPqayOVqfGt5Urv/8QYxl99WnhQlJMJglH0/C/sq24oAy1VoWDqzVGo4m9y+JvWG9qYi6e/k50HxtIu4GNSDqZUamMu68DuRlFtQ6zuenXAsvv82KwbVqPKbvjSc4uMkdCvZEstYn9uQV4thiIe5MuxO2dA0DGhctorT3wDHAjNy2OzAuHLHUV5Zfh6G4evXZr1ImkaPN02NLCbC6VW023QUAvzhz4EUOZeXqpvqSAvPQzVfa1KPcSqFQ0bNaXVn1fpaQwi7LrphdrdfbU82hO0rGVAORlJJB7+TROXsE1XguNzh59SX6N5QDcm3QhNWE3eWnXVqPOTjlWq2Ov1dGZ81HmYFScn8blMztxa9SBksJMDGXFePh1o0XPF9HqHCjMvoBGZ4ehrLjahZrOH12Of6dH6fvUFsufwG7PkBS9vPpOKCraDH4Prc6eQytfwmgw/wx4OtlYiqQaPainykWDvsL26hTnX1sUKG7Pd7j4hGHn0ggr63qoNVZknI+0lMu9fAoHN7/qqqogPyOBevUrL4j0d2Y0GPg8+FFOroqg12v3/6E6XP086frsSPIuZd7m3tWOk49HpdcXCSGEELdCRmSFqEH5USXFCC0SSrAtMWJQFfBd9A4GPRmEd6B56l/P+5sz66ltaHVqnv6mNyNeDOGHSbtx9DBPC7ZzrN2qoVf5t/Ng85wTliCr1qhw87EnLSnPEp49/Z1o08eXj8ZuwLmBLX6hHpyp/o0irP3qKOlJ+ajUCjYOWu59s0OlMlbWGvzb1Sf+UCrNOzcEYOvPMexaFEt+VgkLp+xHo1PzysLBWNtr2bviDIc3JWI0mvBp4cImH4WiwnKL2xgg2V3Dx5tOMyLEixY9/sPOeaPx7/Qo5+O609DnV3b+MAY7Zx9cfcIA80gzYJmG3azrRI6sf5Nts4di6+iFe5NrqwL7d36M07tnsmveGFBUKIpCs/Cnqgw3uWmxnNpuXtzJZDQQ0PlxrB08KpULHf4R0RvfJuHATygqNSHDpqGzdalU7noNm/Xl4PHn2DF3ZIXFnqpi79KYkGEfcmT9ZIz6EoyGMly8QyyLIF3v9K4vid83x/I5eODbtO73Okc3vM32OSMAEy16voiDewDZl04SveEtTEYDRqMej6bdcPZqg6Ko8G41lB1zRqC1rldhsSeDvoSUmPV0fbDia368Wg1hx9yRtOr7WrXnoigKQQMmc+L3jzi47FnCRn3BpAGBltkMZWiJ0/vRSneWhweYR+bi983lbOQvlBZmErXuddQaHT0fX4NWZ09i1GKST67DZDTg1LA1bYe8Z25HpSb0rk85vmUqmIyYjAYCuz2Dg3tAjXUW5pif5613pWxdoVKr+U90za9MqknwmJ633pk/qMszI+5Y20IIIf6ZFJOp+ul6d1JYWJgpMrLml6wL8WfrOm0ryeXC7FVeTjZEvFr1Qk3/BGej09n2UwyPfNLtpo9t8uq6KifnKsDZaUNqVcfamUdx87an0121G2kTf0/lny9v73iRcR77GP7onJoP/BPEbP8MO+dG+La5+460L4QQQtwsRVEOmUymsDvdj78jGZEVogblR5WustGqmTQg8AZH1X1Ngt24HO5JSZHe8i7Z2vJ0sqky/NdmSulVjm42dBgmK5zWdSNCvBgR4mX5nHjECX1poWXxrb+Stb2HZQEvIYQQQtRtMiIrRC1UWLXYyYZJAwIr/HIuKrp+gSwwh/+po4LkugkhhBBC1JKMyFZPRmSFqIXrR5XEjV29VhL+hRBCCCHEn0GCrBDiTyHhXwghhBBC/Fnk9TtCCCGEEEIIIeoUCbJCCCGEEEIIIeoUCbJCCCGEEEIIIeoUCbJCCCGEEEIIIeoUCbJCCCGEEEIIIeoUCbJCCCGEEEIIIeoUCbJCCCGEEEIIIeoUCbJCCCGEEEIIIeoUCbJCCCGEEEIIIeoUCbJCCCGEEEIIIeoUCbJCCCGEEEIIIeoUCbJCCCGEEEIIIeoUCbJCCCGEEEIIIeoUCbJCCCGEEEIIIeoUCbJCCCGEEEIIIeoUCbJCCCGEEEIIIeoUCbJCCCGEEEIIIeoUCbJCCCGEEEIIIeoUCbJCCCGEEEIIIeoUCbJCCCGEEEIIIeoUCbJCCCGEEEIIIeoUCbJCCCGEEEIIIeoUCbJCCCGEEEIIIeoUCbJCCCGEEEIIIeoUCbJCCCGEEEIIIeoUCbJCCCGEEEIIIeoUCbJCCCGEEEIIIeoUCbJCCCGEEEIIIeoUCbJCCCGEEEIIIeoUCbJCCCGEEEIIIeoUCbJCCCGEEEIIIeoUCbJCCCGEEEIIIeoUCbJCCCGEEEIIIeoUCbJCCCGEEEIIIeoUCbJCCCGEEEIIIeoUCbJCCCGEEEIIIeoUCbJCCCGEEEIIIeoUCbJCCCGEEEIIIeqU2xJkFUUZqCjKaUVR4hVFefUG5e5RFMWkKErY7WhXCCGEEEIIIcS/zy0HWUVR1MBMYBDQErhPUZSWVZRzAJ4D9t9qm0IIIYQQQggh/r1ux4hsByDeZDIlmEymUmAhcFcV5d4FPgKKb0ObQgghhBBCCCH+pW5HkPUCksp9vnBlm4WiKCGAj8lkWnujihRFeUJRlEhFUSLT0tJuQ9eEEEIIIYQQQvzT3I4gq1SxzWTZqSgq4HPgpZoqMplMs00mU5jJZApzd3e/DV0TQgghhBBCCPFPczuC7AXAp9xnbyCl3GcHoDWwXVGUc0AnYLUs+CSEEEIIIYQQ4o+4HUH2IBCgKEoTRVGsgLHA6qs7TSZTjslkcjOZTI1NJlNjYB8w3GQyRd6GtoUQQgghhBBC/MvccpA1mUx64BlgExADLDaZTCcURZmiKMrwW61fCCGEEEIIIYQoT3M7KjGZTOuB9ddte6uasj1vR5tCCCGEEEIIIf6dbsfUYiGEEEIIIYQQ4i8jQVYIIYQQQgghRJ0iQVYIIYQQQgghRJ0iQVYIIYQQQgghRJ0iQVYIIYQQQgghRJ0iQVYIIYQQQgghRJ0iQVYIIYQQQgghRJ0iQVYIIYQQQgghRJ0iQVYIIYQQQgghRJ0iQVYIIYQQQgghRJ0iQVYIIYQQQgghRJ0iQVaIWlo4oivzB7fHaDBYtsWuWcycjo05seTHW6o7du0Scs4n3PRxKYf28kP35iwfN4hl9/Vn/bPjyEtJuuExeSlJnFrxa4VtC0d0JfPM6Ztu/69WXT8zYk+QsGVthW1zOjamrLDglto79N3n7P/i/QrbTiz5kR1TXvpDx9ZGzvmzbHl1IgtHhLNi/BCWPzCQgzM/rPDvrrZilv/CsQVzAPO/sS2vTqy27PGF3xP9y2wAClIvsW7iWH7sHcTKh4ZVKGc0GNj72Tssu68/S0b3Zt8X72Eymcx1LPqB5eMGWf782Ks1+6a/W+F4fUkxS+/tW6Hek0t/5si8mTd9fkIIIYT495IgK8RNsHXzIHnfTsvn2PXLcGsedMv1xq5bSs75s3/oWOcmAYz6ZQN3L9iMi18g+75474bl8y5e4NTKBX+orb+rjNiTJGxZd6e7ccsK01NZO2E0vuG9GbtyNyN/WsfQb5egLy7CWFZaqbxRr79hfS1GjSPovsdqbFdfXMSJxfNoec94ALS2toQ+8R96TZleqWzs6kVkn4tn5M/ruHvBZrLPxpHw2xoAWt/7MKN+2cCoXzYwYt5q1DodfgPuqnB85Def4BEUWmFb8xFjOb16EaX5eTX2tTamB43mq/YP8E3X/2Nmh3Ec/mlNrY47tyuKM1sP3JY+3IpVT33A150eZOnD/6u0b9/XiylIy7J83j71eza/ees3Ad5x6kZpfuEtHfdN+MOUFZVUWS7vYjpz+0/EZDQCsPnNmXwRPIZ3nLqRerLiTbzYTXv4tvsjzOryEPMGP0PWuZRr+zZG8G23R/gm/GFmdXmImNU7LPsW3v8a33T9P77t9gg/DHqaS9FxAOhLSpnd8zGKc/Jv+vyEEEL8fUmQFeImBAy5h9h1SwHzyKahuBhnv2aW/WWFBeyY8jLL7uvPsvv6c/SnWZZ9ayfey/4ZH7Dm8XtYNLIbB2ZOA8yjuukxx9j76dssHzeI5AO7WXZff9JOHrUce+zXOez64LUa++fVPpycxATSTh5l2X39K+xb/sBALkcfYs/Hb5F1No7l4wZVGKE7u2Udqx8dycIRXSuMMKedPMrqR0ey7IGBrH50pKVfeSlJ/Nw/hIOzPmbFg4NZMro3l44crLJf8ZtWseqRu1jx4GBWPDiY5IMRln0LR3Tl0LefVdn2pagDLLt/AKsevos9n74Npsp1F+dkcWj256Qc3M3ycYPM5a44sXgeK/9vOItGduPs1g2W7anHo1g3cSwrxg9lxfihnN+9tcZrW52jP82yfN87prxc5Shwbb/Pk0t/omG7zjQbOtqyzcregc4vvY3G2gYwX6+ouTNYN3Esu6e9TmFGquVclo7tx/4vp1qOre2o8NmtG2jQtgMaa+srbdajYUhHNDa2lcpmxMXg1T4clUaLSqPBq0M34jetqlQucdfv2Li6494i2LLtUtQBcpPO4T9oZIWyKo0Wr47dKo2q34oxP77LkxHzGD1vCute+oy8i+k1HnNudxRntlb9b7gmf2TEvCr5qZmcXLODiXt+5J4f3qm0f9+sJRWC7N/Jk7t/QGujq3Lfjo/n0eGJu1FU5l87mg/pxv+t/xJHnwYVyhVl57Fy4gfc8/3bTNzzI6EPDWPdS58CYDKZWDHhPUZ++yZP7v6BUbMns/Kp9y3heMSsN3gyYh4Tdn1P52fGsuoZ88+CRmdF8Jj+7J256E86cyGEEHeC5k53QIi6xLNdZ2KW/UxJbg6xa5fgP3gU6THRlv1R388Ak5FRv26irCCf1Y+NwsW/OT5degGQfzmZod8upqwwn0WjehA47F6aDRtD7PplBD/wBL7hfQBoOXo8J5f+TI+32mAymYhZ9gt9pn59w76ZjEbObtuAa2Ar3Fu2QWNjy8XD+2gY2olLUQdQVCrqB7ejy6QpHJjxASN+rDhKpS8uYvjcFeSlJLHs/gE0G3IPKq2WLa9OpPubH+HVIZzkgxFseXUiY5ZtB6AkJ4v6QaG0nziJ+I0rOTBzGsO/W1apb96duuPXfziKopCdeIb1Tz/A/Wv33bhtjYatk5+l5zvT8WzXmYQtazm5eF6luq0dnWn3xH84v3srfafNqrBPa2fPiHmruXQ0kq1vPE2T3oMoycsh4sM3GPD5PGzdPChMT2Xl/w3n7gWb0Dk4Vqo/bsNykg/utnwuzs7Cq0NXAJL2bCN+wwqGfbcMrZ09O955iajvZ9DhmYohtbbfZ/qp43h37FZp+/UKM1IZMmuh+dqVFNP/07lobe0w6svY8Nx4kvZux6dzzxrrueri4X14tG5bq7JuzYOIXbuEFvc8CEDijs2U5OdWKhe7ZjGB5QJ5WVEhez+fQv9P5pCTVHn2Qf2gUJIittF8xH217ndteLRsio2TA7kX03Bo6AZAxBfzOblqB0a9nnoN3Rk2478UpGcT+cMqTEYjCdsjaX13H7zDWrF58kye2G6enn1uV5Tl87ldUWx8bQa+nYNJiTpF95fHc3LVdjTWOjLik8hNTsW7fStGfPMGiqJU6tfRBRvZ86V5ZoRLEy+GTp+ExlrHj8Oeo6ywhG+7P0qb+wbS+el7Lcfs/OQn8i6ls/ihyWh0Vtw95y0A8i6mMX/0JLLOpeDSxJPR895Fa2uNobSM39+dTWLEUQylZdRv2ZQhn72ElX3lGxTlpcedZ9NrMyjMyMFQWkbHiaMJGTcEgJjVO/j93dnYONcjoF+nCse949SN1y5sqlS/vriEkyu3M/CDZy3bfDsHU5XMhAvYezjj6u8LQED/zqyY8B6FGdnYuDiiqFQU55pHVotz8rGv72oJx9aO9pZ6SnILLNsBWt/Tl9k9H6PX64/e8NyFEELUHRJkhbiBlVHJfLzpNCnZRTyXU8zWU2k07TOUM7+tJmHLWoZ9t6xCkE0+EEHnF/+HoihY2Tvg1384yQcjLEG2ae8hKCoVVvb1cGrsT25yIo6+TSq1GzD4bqLmzqA4J5u0k0ewcXHDtVnLKvt4dXQVkwkX/xZ0ev5NAFrd+zAnl/1Mw9BOnFz6Ey2uTButTtP+5mcWHTx90Dk4UpB6EaNej1qrxatDOABe7bui1mrJSUxAa2uH1tbOEr49Woewv5ppzbkXEjn0zXMUpF1CpdFQlJlGYUYqtq4e1bZtKCtDo7PBs11nc5m+Q9k9teZR6fL8+g2z9K0w7TL6kmJSow+Tl5LExhcespRTFIXcC4kVRg+vChg0io7Pv2H5fGLJj5bvPPlgBE37DcPK3gGA5iPuY+9nlUfRbub7LO/oj19z5rc1lORk0/v9r6gf3M7Sp6tMRiP7v/yA1OhDmICijDQyY0/eVJAtSL2Ib3jvWpVtNvQe8lLOs+bxu7Gyc8CtZTAXD+2rUKYwPZWUyD30eOsTy7YDX35Ay3vGY+fRoMoga+PiTkHqpVr3ubbO74vG1tWRBq39AYhetInMhGQe2/INikrFwbkr2PzmTEZ99xZhD99FaUER/d97GjAH1xtJPZnAkM9eYvDH/wHg5KrtpMYkMH7l5ygqFd92f4SE7ZH49Wpf6bgt73zDE9vn4NDAja3/z959R1Vd/w8cf97F3nuDoAxBBMWRuPfOrWXOsqzULDVtaWbDNMtRqblz5N57762A4sAFKhtk77t+f1y9iqDgqr793o9zOqf7+bzn53KQ1+e9vp3Pjk+n02PRRPqunsofzYYw9OiiMvU1Ht2f80u20GvJJByqe9+/eoDEiBiG7P8DQ0szlnUbxYU1u6k9oDPHZqzAyMKMIft1a5/3TJjNkV+W0eKrd5/YJ41Kxfp3JtJt3njsfD0pzi1gXrN3cK8bhLG1BVs+msLg3bOxq+bBsRnLK/UdJJy/io23K3Kj8kdrH2Xr405eSgYJ56/gWiuAC6t3A5B9NwUTWyt6LJ7Iyjc/x8DEiOK8At5cPaVU/s3DJ3PzwBnQQt+1D3/+zBxskCnkpF+7jZ2vZ6XaLQiCIPy7iUBWEJ5gY0QCn62/SKFSN2VQrdEyfe81Pm7fkMJpQ3EKrYeRpfVjubTw2OiLhIefZYYP/5CTyKRonzAdUW5kjE/r17m2dQ1J509S/f7oV3msq1QrM7oK4N2iPWd/n0J6TDSJ507S+KupT+2vzKB02zRq9f1NfMqOJj3oo1Rh8PCSVPrE6ZUHvhpBvY++wKtJG7QaDYub+KMufriWrry60ZYzj/gZPShXKpMBoL3fJ5uqAXScu/qFy0dbzvddzuhbZb9PW79A0h55MVJzwAfUHPABGwd0Qv3IGlm5ian+/6NXzKckJ5vOCzciNzTiyPefoSopf53ik8gNjUp9H08jkUoJGzqasKGjAYhaOgerKlVLpbm+bS3uDZphZGWjv5YcdZa7xw8QsXAG6uJiinNzWNe3Ld2X7wRAXVKM7P7U5pdh9YCvQKslIzaR3su+Q2agACBmxzESI64yt7FuZE6jVmNkYfq0op7IxscN97pBpa75d2ikD9icg33JjE2AxwLZ2CPnqdaqPuZOuhHisEGdmdNw0HO1AcCnRV2MrHQvU1xrVyczVremNGbHMYpz87m86SCAblQ2yOepZd27cZe0a7dZO/hr/TVVsZK0mNtIZVKca/piV003Wlp7QGf2TphTYftyEtMws7epMB3oRlV7LJrIrs9noSoqoWrL+hhZmiFVyNGoVBz9eRl9VnyPR/1g7py8wNrBE/jw5FL9KHDnWeMAiFq5kz3jf6fvmoe/98wcbclJTBOBrCAIwn+ECGQF4Qmm7orRB7EPFKs0/Hw+jwVDR2MfWHYqpmvdhsRsWoljcG2UBfnc2rOFuiM+r7AuA1PzMhvdVO/Zn63v9UKrUZeZMlsZUrkC30492TN6CFXbvq5fY1leXU9i5eWDWllC4tnjuIQ1IPHscTQqFZYeVShIS6l0W0pyczB3dgcgZvMq1CVlNy4qr25VcRFJEadwDq1H7L7tT2y3wtSckvzK9ckxuDbZd2P1fQLdOmC7gOByg9Cnca3bkNO/Tiaw10AUJqbEbF6Jy/1px4+rzPdZvUd/NvTrwPXt66nWXjfqqlGrSwWxjyvOy8HEzgG5oRH5qcncPryHgO59n6kf1j7+ZFVy12xVcREaZQkGZhbkJSdwZd1SWk6eWyrNtW1rqf/RV6WuPQhYQbfb9uPT27PibmBbNeCZ2v2oR2dP9M4uoubEUbzRrT6XNh5gw3uTGHZ2BWYONqDV0nj0AEL7daiwTKlcpl9/CbpNgx5lYGpcJo/c8JGXOzIpGlU5L3e0lHkBUubzM3i0TqlMiqrofp1aLR1++oQqTWpXuiytFkxsLcsdEb667chztU9hZICqki9KALybhuHdNAzQrRk+PusvrL1cSL54g9zkdDzq62ZOeNQPxsDEmLRrt3GtVfpnp2aftmwdOZWCjGxMbHRLBlRFxciNDBAEQRD+G8RmT4LwBIlZhU+87t/1zXKnhoYOHgFoWf9mG7a8042q7bpWaoqnf5c3iFg4U7cR0mndekxzF3csvXzw7dQLmeL5/vjy69yH/LRkArq9pb9mU9UfS09v1r3R+qnHsQDIFAa0nDybs7Onsq5vW87OnkqLH35/5vbU/3g8ez59ly1DepCbFI9hmZHscuo2MKT5pJkcnzqeTYNeJ+3qBcycXMtN61qnAarCAtb3bVtqs6fyGFpY0vqn+ZxfMIP1fduypncLzs+b/lwjwO4NmlG1bRe2vNON9W+2ASB00PBy01bm+zS1d6Tj3FXEHdrFyi7hbBzQia3v9cSrSRvs/ILKzRPYayApF86xoV97jk35Etc6DZ65H17N2pTajVujVrOiY332f/4hGTeusqJjfc7N+wWAkrxcNr3dlbV9WrFz5EDqfDgOO/+HbUuOOouyIB/X+o2fqQ3xJw/j1bztM7cdHs6eSMgqRAuoNBpm7L3GxogEArs0w6dZHY7+sgwA33bhnFmwgcIs3YsPVXEJyRdvAGBobqJffwlg5elMZlwShVm5aLVaotfufa72Pa5Kk9rc2HOSvJR7AJxbsgUhHRYzAAAgAElEQVTvppULNh9v49P4tgvnxO+r9DsJF+cWkBYT99Q8dtXcURgbEbXy4YuH9Gu3Kc7Jx71uEEkXrnPvpu6Ir/NLK7c5l0OgD+nXn34s2KMePBetRsO+b/4gbNDrGJgaY+FiT05iGunX7wCQFhNHXso9bKq4UpJXQHb8w5drMTuOYWxtgbG1BaD7mc6MS8IhwLtshYIgCML/JIn2JUzfexXCwsK0Z8+e/aebIfw/Fj55PwnlBLOuVsYcG1e59YQvoiQvl7W9W/D6wk2YOjo/VxnXd2zg1u7NtPml7OiK8Pd6Gd/nq7RjRD/qfDj2iQHz89r683BkcgNkct3UXvsq1QltV3q9dlbcDY5O/pyOcyqe7n1m4x94hTTG3sufhCtnMDK3pvOyOyRkFeImuUcj6RWUSy6wt31PTL09ODauORm34vmj6TsMO7McM0dbTvy2isjl2wHdTrh13u5KnXe6khmXyOp+X6LVagnq3oKGH7/FoSmLiVy+HfsGZhjaSynJK0RhKcHA0JL81Cxsq7rTcuj3rP26L4q0AFxDA6n7bncANr7/HS6h/vrPj3p0sydrLxc6Th+DmYMN1w7v4fBvc3hn1TrUKiXHVvxERqJutLzLuHmc/3MLx2asQGFsRNjHjbl94RhajQb30DDCOg/hyNSllOQX4t7aldtRR8lLy6QgsZD8K3IkSGnwcS9S0o+h1ajRajSY27tQq/0gfvToxPCLS4g+sJrABm+y67OZZMenotVoMLW3oefiiZjYWpXa7CmwSzN2fT5Lv8HTkzZ7At3RPD0WTdRPS97x6XSubD1MXkoGJraWmNhY8MHJpYBunevdU9GoS5R4N69D2++H66drX1i9m2PTl+tnTzT9bDD+HRuTl5rByjc/Q1lQhEQqxdjagtaTPsA5xA+A28ciOTLtT95a/3OFP2OCIAj/JhKJ5JxWqw37p9vxbyQCWUF4gsfXyAIYK2T80K0GXULLHxl8Wa6sX0bEwl8JeuNtgvsOea4ydozoR27CHVpNnY+1d7WX3ELhWbyM7/NVy74TS87dONzDm73Ucrf+PJxGfT/F0tH9iWniTx3B1N7pmX9OT6+fjbWrN603qMo7mQkJEDu54inEz6q8Pq0e/wZdv1iEwvDF1vnu+vVTGvUbi4mlLRq1mrS4yxiYmHNoyXd0GTdPny75xgWidi2jxZBvkCkMObt5HmbWjgQ0fv2p9zRqFRq1Gvn99eMRO/4kPzWDc9OO89GF1RxdMQ3f+m1x8A58oX487uLavcSfuUS7Hz96qeVW1rp3JhL6Vgf9lGVBEIT/FSKQfTKxRlYQnuBBsPpg3Z2LlTFj2vi98iAWIKDbW6WmAz+PdjOXvqTWCC/qZXyfr5qlR5Vyd9B+VQ4s/Aa/8I64+NXCrV4j3Wel7nN2ajxnNsxBpSzGysmTvIwUqjfpiotfLX0+qVRGYsw5Um5FM9oQ9in9ydKa0FF2npmq9vSQnaDQyEFfX3bKXY6u+In2I6ejKi4kcucyslPuoFaV4FAlkJpt+yGVvthqm+snd5Jw5QwlhXnUbP0mboH1ALh39wYX9vyFqlg3wyOweQ9c/GqVyZ8WdxUDE3NMLG0B3SZljj41yM9MK5M2K/k2dp7+yA10gbNztRAu7V9LQOPXn3pPKpMjlen+6ddoNNw+EUFWbApt7weYHjUacOv8gZceyNbo0ZLCjGy0Gk2pY3H+DqriEjwb1BRBrCAIwn+MCGQF4Sm6hLr+LYGrIPyXHV81XT+1OLjVGzhVq/nU9KfX/Y5vg3Z41mxERsJN9v3xVZk0TtVq4uJXG2tXb9QGQVxZfxFnVYL+/kVpNd4xuaj/HBtxEK+QxkgkEiJ3LsPeK4A6Xd5Fq9Fwct2vxJ4/gE9Yixfqp8LImFZDvyP9dgwnVs/ALbAeJYX5nNsyn0b9xmJsbk1hbiZ7536JnYcfBsald0tOjbuMrVvVJ5RemrVLFW6d209xfg4KI1PuRp8kPzu9wnsP7P59HAXZ6Vh6edDh8+9QGOmmA9u6VyNyx5IXeg5PUt4U67+D3NCAsMFd/pG6BUEQhFdHBLKCIAjCK9Wg98inTi1+lLKogOzUu3jU0O3+bOPqg6Wjx1PzPHjZtGJ7OhTq1rG/36YlBociyUq+jYW9G3cuHqfFkG8ASIw5R0bCDa4d3waASlmMiYXt83ZPzyNId+axjXs1CnMzUStLuHf3GvlZaRxZ+mOptHkZydi4lj4KpzAnA3M7l0rV5egdRNW6rTn05w/I5AocvIOQ3pRVeO+B1h9MRqNWEbF9CTfP7MW/UWcAjMysKMrLRqNW6UduBUEQBOHfSPwrJQiCILxUjx6F84VhEfuuptDtsUBWIpWh1T482katUgK6k2mQSJ75OJouoa40sKpF1K7LfDJUtxnbpexGxEUexsGrOhZ2rpha2esSa7WEvzEKMxvH5+5jeaRy3W7UD6YoazQatFotlo4eNH97QoX5ZXIFGlXFR1M94PtaO3xfawfA3egTWNi7Vuqevr0yOV4hjTm7aZ4+kNWoSpDKZCKIFQRBEP71xPE7giAIwktT9igcLTP2XmdjREKpdGY2jmQk6HbjzU6NJyv5NgAGRiZY2Lty5+JxADITY8lOLf/oFrmhMcqigie2xSukMXcuHufW+QNUqdVEf93FvzZXj2xGc/+M2OL8HPIyUwG4fmoXF/b89XydL4edhy9595JJvXVJfy0j4SblbbRo6ehBbnpSpcsuzM0CoKQwjytHNuMX3qHCewXZ91AWFwG6423iL58uNVqek5ZY4Qi4IAiCIPwbiFeugiAIwkszdVdMqZ2+AYpUGqbuiim13ty/YSdOrJpB8vVILB09sHby0t+r1+0Dzmycy7Vj27B2qYKVoycKw7JHuniFNOL0+tnEXzqFb4P2mFjalbpvamWHhb0babGXqd/j4fm+Ie36c2H3Cnb/PhYJEqRyOSHt+mNm7UBOWgKmVg6PV/XcDIzNaNh3NFG7lhOx4080ahVm1g407DumzKizi18oVw5vLLUh0p45X1CYk4GyMJ8tP32IU9Wa1OnyLgCHl3yPVqtBo1FTtV4bXAPq6Mt60r3c9ESidi1Hq9WNFls5eRLafoA+X/KNKNyq131p/RcEQRCEV0UcvyMIgiC8NFXGbXvho3BUJUXIFIZIJBKyU+M5uGgS7UZMw8DY7KW2tTwHFkyk4VufojA0fuV1lefs5vk4Va2JW/U6FSd+ydQqFfv++JImAz7H0NTib69fEARBKEscv/NkYmqxIAj/Gt712hN99Ual0o79djpGXnVIu5dR6fJz8/IZ8eVkfMM7E9y8B8HNe/DDzAXP21wArt+6Te3Wfajdug/L129nyOiJHDl1vty0g0aO57dFK1+ovsWrNnPt5m395827D/LppF8qzDdx2hzGfPPzE+9/MuEn1m7dA0BkdAyNXh+Imc9r9BwyulS6vPwCBoz4kpotelK9cVemzfmz1L2C0xtI3jKLpE3Tybl0VH9PdWkftVr11v9n4l2PWQtWADB78Womz3r4PaTfucbu38ex67dPOblmJmGdh/wtQSxAs7cn/GNBLEBQi16on2Gd7MtUkJ1GjZa9RRArCIIg/E8QU4sFQfifo1KpWL5+Gw3rhLJs7TY+fq9fhXm0Wi2d+g+nRoAv0QfWYWCgoLCwiAV/bXihtmzYsZ/Xwmry6/efAdC3W/sXKq8if67ZjJ2NFb4+ngB0bt2Uzq2bvlCZ8Ykp7Dt6imlfjwLAwc6anyaMIvJSDHsPnyyV9oeZCzAwUBC5dzUFhUU07DyA8Doh1K8dzA8zF1DT05Y7DbpTUFhE6q4/MHTwxMrFix++GaWfWpx2L4MqdTvQs1NrAN7p25XqTbrxwcDeWJib4VQ1GKeqwS/Up/9VRqYWeAaH/yN1m9s6Y27r/I/ULQiCIAjPSozICoLwP2f7/qP4eLrz9Zj3WbRqU6Xy7Dtyiri7Sfz89SgMDHRnmhobGzFs8BuAbjRx8McT9CO1U35bpM/bvMc7fDrpFxp3GUTV1zry2fczAFi+fjvT5y1n7dY91GrVm5txd2ne4x227jkMQEJSKq16vUdoy150Hfwx6RlZ+jJzcvMYMnoi9Tu8RUjLXowcPwW1Wv3U+hat2sTZqMuMHD+FWq16s/fwSRav2qwfNU1OTadFjyHUafsmNZp1Z+y30yv1bBav2kT3Di2R3F+z6eLkQL1aNTA0MCiTNuryNVo3aYBEIsHUxJjGr9VmxYbt+ntDurVkcvdg3O0tMXTwQpIYzQ/dapRaH7ts7TZaNKqLk4NuTatCoaBV4/qs2ry7Uu0VBEEQBEEQI7KCIJShUqtZsW8fh6KikEmlaLVa6vj7M7hdO/ZHRHD6yhW+7FfxKGhlfLVwIe+//joutpU/x3PRyk0M6N2ZhnVDKSlRcjoimrqhQaXSnL56lfGLFjG+f38aBAYSEX2V0Br+KBSKcsv8dvo8NBoNUfvWkJuXT3jnAdQIqEa75g0BuJOQzMH1C8jNy6dag84M7tOFvt3acyP2Dnn5BZh72aG6f1TnjcQEhs+cybq/tlMnuDoRq+dy63Y8oa160+i1Wny9ZAmr/9qKo4s93036hGYhIbw17HN+XbyKTLmSa3fjuXMvjdlTv6Kurx/VGnRGY2FArqoYC1sL/ML80JgqMLWzgKRU4pKTORAZyWv+AWxaMgMzUxOUSiXt3vyQnQeO0bbZ00f4Dp04x6j3+1fq2dcODmDdtr10aduU7Nw8dh88oR8dfnBv6aymNPQ0odG2mfh6eJYKYgEWr97MxDEflLpWv3YwO/YfZUjfbpVqhyAIgiAI/7+JEVlBEMqYtmYNt1NSmDViBH+MGsXsjz/Gzd4epUr10uuaNHjwMwWxqekZHDpxlp4dWwHQv2cnFq3cWCbd7jNnCPHxYdeZMwDlHnfyqH1HTvFO325IJBIszM3o83pb9h05pb/fo2NLpFIplhbmBFSrws3b8fp7GTm5FJWU4OeuO8bExsycj7p3J/deDuENdfszeHu60bxhXY5FX6KaqysZifdIj02h18BPCGnZi/MXrrB+30Gqubri6+7G+A/f4c/duynRqAmoVoVmgcH8PnIkvm5udG3YCDNjY2r7+gLgam/Hsj17UKpUfDrpF0Jb9qJOu75Ex9wg6lJMhc80PikFR/vKfQdjhw3CzsaKuu368ub742jyWhgKhbzCew+cjogmNT2DDi0alrru5GBHQlJqpdogCIIgCIIgRmQFQSglIT2d49HRLPv8c0wMDQGQy2S0r1dPn6aguJjvly8nLjkZM2NjvuzXDxtzc2KTkvh140aKSkpQqlS0q1uXro0aAbD91Ck2HDmCQi5Ho9XyRd++uDs40GPit6TIaxCfKyc1M5ufN+7EylJGRk4OjYODGdyuHQC3U1L4ec0aTh+LoLCoGPe6bTE1MkImkZJfWMjPX4/G2NgIgJz8fCJv3mTeqFG8+/PPZOTmUqtGAL8vXs2o2bPxc3cn5u5dUjIz6RIejq2lJXdTU/l22TI+N5LRODiY6NhY0jMfTgVWaTT0mTSJxWPHIpNJUakeHjFzKzmJPm901H+2sbCgqqsrpQ9X0bmXnU2Ynx9arZZNi2ew5MBegr296d64Me9Om0aYnx8LABtLS7xdXDh84UKZ+s5fv0azkBAM5Lpf4QqZHGcbG8ZOnklmdg4nti7FyMiQ9z6dRFFxxRsHGRsZUlRUXGE6ABNjY/16YIAPP/uegKreFd57YNHKjbzVvUOZkfGi4mKMjAwr1QZBEARBEAQxIisIQik3ExJwtbPD3KTsuZ0PXIuPZ0iHDvwxahQeDg5sPnYMAEcbG34YMoTfPvqIGcOGseP0ae6kpAAwf9s2vn/nHX4fOZKZw4djb2XFxogEsgqUpOQUowW0QGRcCo3qdeK3ESPYefo0CenpAExdtYrODRqQl5zF7GnjadA5nPXLZ3Ln3C7qhASxbvs+ffv2nT9PvYAArM3NCQ8MZN+5c7RoVA93F0cO7T5O8r0Mpr73Hj8OGcKEaXO4nZzMwO6dMC2SMHfzZnLz8rkYdRWloYTCYl2Ad/ZaDM1CQjAqZ91oelYW/vdHYx8VEFCVE8d1OxjH3klg/9HT2FtZcSgqik6tmvD1tDlcjo0jJTOT9IxMbI3NOBQVhVYLmXm5XLl9m5TMzFJlmpmacP7qNdrUKX08S4CnJ7fiE3F2sMfIyJCEpFQ27zr49C/7viD/asQ8shPy0+Tk5lFYWATAhcvX2LjzAO8P6FnhPYDCwiJWbd7FoD6vlyn36vVYalb3rVQbBEEQBEEQxIisIAilVOZk6eqenthbWQHg7+FBxPXrABSXlDBr2zZik5KQSCTcy8nhVlISHo6OhFStyrQ1a3itenXq+vvjbGvL1F0xGD1WY/Se/by5/wj25oZk5+cT06EjX343k0tpCfQNb0Jmdg79u7TnzN2b+jxvdm3H4pWbeKt7Bzr0G4axqxVfvjMQgFZhYfyydi09mzZl27JfafrWUObNXMa6P7cAYGhlTIOgIHo0asywz39g/YqdXNgXQf+enTB0smDf+fNotVrOX7vGyAFvlPs8CotLsDIrezxM376dmTPnL0Jb9sLXx4uWjetTPyiQzLw8tE6mXDlxkfijiZzcfoLFdqv4ZuwwopLvcD0hnh2nTlEzyBe5TFaqzPDw2kyZtZBeAz/hxy9H6q9bm5sTUjeIg9uOULt1H9xcHGnesG4lvk3o2r45a7bsZmDvzgDE3U2kcZdBFBQVUVRUgkftNkwYPZS33+jKrdsJ9Bn6KXK5DCNDQ5bO+g4XJweAp94DWL9jP/4+Vaju61OmDbsPnmDS2A8r1V5BEARBEARJRevG/ilhYWHas2fP/tPNEIT/NzZGJDB1VwxpmRlU4TyDu71N73rlBBxnz5ba7OnRzz+vWYO5sTGD27VDJpPx+fz5NA0JoXVYGFqtlmvx8UTeuMG2kycZ3rUrvRbfxFt7irsEUSIxxUMbxT3cKJDYEju5A2PmzqVH48YEeXnR59tv2fztt/qddT+cMYP+rVtTLyCgVPuuxcfz8W+/YWtpqb+WkZPDlHffpbqXl77MB/n6T57MNwMH4uXkBEDbsWPZ8M03GBsaEpeczOS//uKtli3ZfuoU37/zTrnPrvuECfwxahS2FqXP31y6Zw9FxcUM6dix3Hyg2+yqQVAQ7eqWDTrLu/fFggXUCwigc4MGpdJuPHaMuKQkRvbo8cS6nkStVlOv/Vts+XMmzo72z5z/RV29Ecv7Y7/lwLoXO9NXEARBEP5rJBLJOa1WG/ZPt+PfSEwtFgSBjREJfLb+IglZhZRIjMnFhl83bmD16VgA1BoNG48e1U+zfZL8oiLsrayQyWTEJScTHXs/v1pNUkYGfu7u9G7WjFrVqnEzMREXK+Nyy3n8uqmxMR4ODhyMjATgekICscnJ5ebdfeYMPZs25c9x4/T/vdWqFbue48WYl5MTFiYmzNmyhU6PBY6Pp4tPS6tUmTn5+fpjdiJv3CA2OZlmISEV3gNIy8oiOja21LUH7qam4u3iUum+PUomkzH7xy+JvZPwXPlf1N3EFH774fN/pG5BEARBEP43ianFgiAwdVcMhcqHmwkl4oed5jbzN/zJvqPmuuN3/PxQyJ/+K+ON5s2ZumoV+yIicLGxIahKFQDUWi3TVq8mv6gIiUSCvaUlg9u1w8g6i19XHipVhqFcypg2fmXKHtO7Nz+vWcO6I0eo5uqKt7MzpkZGpdKUKJUcjIri5/ffL3W9WUgI7//yC+937vxMzwWgbd26LN65k7r+/k9MEx4UxLlr16jpoxvBjo6NZfKKFRQUF6PVajkUFcXIHj0I8/Mj5u5dZm/ejFQqxcLUlIkDB+rX3T7tHsDe8+epHxBQZv2yVqsl8sYN+jRr9sz9e6BOSOBz531RrRrX/8fqFgRBEAThf5OYWiwIAlXGbSt3bawEiJ3c4ZXW/WBKc2JWIS5Wxoxp41fm3FGAopISDBUKJBIJt1NS+HTuXOaPHv3UTalehl/WrsXN3p6eTZo8MU1+URGjZs9mxrBhGD7hnNpX6WxMDPsjIvi0T5+/vW5BEARBEF4dMbX4ycSIrCAIuFgZk5BVWO71V61LqGu5gevjLsXFMX/7dv15sCO7d3+lQey9nBw+nTsXG3PzCkdyTY2MeLdDB5IzMvB0dHxlbXqSguJi3m7f/m+vVxAEQRAE4Z8iAllB+A9a9tEQ5AoFMoUCjUZD7S49qfpa43LTHpw3i48Cg5lwWlZqerGxQlbuFN+/y5l1f3Fp7w5MrWwALXIDQyYNfh87zyrlpr+0dwcqZQk125VztMuhfdyJOEPrkeMqXb+thQULxoy5n38vF3duBSDvXhpyA0OMzHUbOzV++31OrvyTkPZd8PR9seNj8jPvsXvGj3QZPxmJVMqJ5Yu4deY4uWmp9Jo8Ext3T33a2xFnObN2ORqVGkMzMxTvfQT3N5u6ff4Mp9cuBy1otRrCur+Bd53XyElLYdfPP+jLKC7IR1lYwKA/lqNWKtk4cSwdP5+EoYnpC/VDEARBEAThVROBrCD8R7X+aCw27p6kx91iw9djcQ0Kwdi89K66Go2apkOGA2DgVrkpvn8nv4bNeK3vIACi92zn1Mo/6TB2Qpl0GrWawJbtXlk7/Ju0xL9JSwD2z5mBg3dVglq//CnX5zasJqh1RyRS3T58XmH1qNG2Ixu/Kb0RUnF+HgfmTKfL1z9i5ezKtaMHObJoNh3Gfo1Wq2Xf7F/oMv4HbNw9uXcnjo0Tx1Kldj0s7B3p+cN0fTnHls5Hc39zKZlCQbXwplzYvok6Pd586X0Tns3gT79n/IjBeLk5PVO+cVNm061NE+rWrM7MxWto3qA2Qb7er6iVDy3ftJuiomLe7t3pldf1qj36DB+Vkp5BxKVrtG3ycE33835Pj9p79AynL1zh8w/6P3cZD2zac4Qm9UKxsih7HBiASqVm5da9HD4diVwmQ6PVElbDn4Hd2yOXy8rN86q8SL+/+20JPds3x7eKO+ejY/hz/U7iEpLo1Dy81M9gZnYOv/65jpT0DFRqDb07NKfZa7UByMrJY/rCVaRnZqFSqQn2r8p7b76OTCZ7ar6Fa7bi4+FKk3qhL+dBCILw3EQgKwj/cXZe3iiMjclNTeH2+TPcPHkEI3NLMhPu0nTIMI4tW0BI+y50qVUHi1NrkdsryEpOJG/pavaf9KPZ0JFIJBKKC/I5vmwBaTdvIJFKcPKrTqOB76FWKTm9ehmJVy6hUamwcfek8eChKIyMubx/Fxd2bEYmV6DVamg14lOsnFw4suQPEi9dQKZQIDc0ouvXP1bYj5KCAgxNdX+c5aSlsP7LUQS27kBCdBTVwptQkJ2FqqiI1/oOQq1ScnTJPBKvXMTU2hYrF7dSZUVsWc+t08fRatSYWtvS5J0PMbGyfqHnnHg1mogt68jPzMCnfjj1+wwAID8zg2NL/iD3XjrqkhKqNmhErdd7lsmvKinh1qljNHjrbf01Z7/qZdIBZCcnYWxphZWz7kWDR0ht9s/+hcLcHIzMzJFIpRQXFABQnJ+PiZWNPjh+QK1Scv3YITqM/Vp/rWqDxqz74hMRyP5HjBhY9udMeH4p6ZnsPHSqVCD7b7NpzxFqBlR7YiA7fdEqSkqUTP/qI0yMjVCp1Ow9dgalSlUmkFVrNMik/77DLWJu3aGouATfKu4AONnbMnxAD46fu0iJUlkq7fxVW6jq5cZXwweRnZvHyG9mEOTng72NFau37cPd2YGvR76NSqXm08m/cfx8NI3q1Hxqvu5tm/LpD7/TqE5NpP/C5yMI/5+IQFYQ/uMSLl1AXVKCpZMzGfF3SIq5Qs8fpmPp6Fxu+oz4O3T87BskUglrP/+Y+Ogo3GuEcHzpfBRGxvT8YToSqZTC3BwAIrdswMDYlO6TfgLg5F9LOL95LfV69ePkisX0+nEmZrb2qJVKNBoN9+7EkRAdRZ+pv+kCrvy8J7Y95ugB4qOjKM7PRaNW0/nL7/T3ivJysXZxo073NwDdVOQHLu/bRW5qCr0mz0KjVrN50meY2zkAcO3oQXJSkug2cQoSqZRLe3dwfPlCWn446oWec156Gq9/9T0lRYX89fF7+DdthZWTC/vnTKd2l964BASiVinZ8v147L2r4V6j9BE6abeuY+HojPyRXYqfxNLZhYLsLFJvXsfBpxrXjx3St8HY3IJWw8ew6+fvkBsaoSwqpN2Yr8qUEXfuNKbWtthXeXhWsImlFVK5nMzEeKwfC/6Ff864KbPx9XLn6s3b3MvKoVGdmgzsoVsTfScxhekLV6FWa3B3cUCpVJXK92Bk8eDJCDbvPYJKpRuBH9yrIyHVq+n+/9Pvad6gNhGXrpGZnUvXNk3o1CIcgAWrthB97RZKlRoLM1NGDuqFg93TX/qoNRoWr9nGuegYAGoH+TGwZwdkUim/LFiJQqEgMSWNtIxs/H08+OTtPkgkEgoKi5i/agux8UkolUpq+FXlnT6dkEmlrNi0m8OnI1Eo5EiQ8P2nQzEzKb2GP/LydZZu2IlSqUKt0dCrQwua1At5oWf4qDnLN5CSnsHwr3/G2cFOP5J49GwUs5asKfPs4pNTmffXZnLy8lGq1LzeqhGtGtap5LcOcfFJ/L5sA8XFJZQolbRtUp/XWzUCYOehk2zccwSFXIZWq2Xs0H4cP3eRjKwcJs/+E4VCzph3++Lh8nDNfkJKGifOR7Pkpy8xMdbt+C6Xy/SB+d6jZzh8JhJLMzPuJKXw0cCefPvrklIjzg9GoD1cHJizfCMXrt5ALpdjbGTA1M+GoVar+XrGQnLzCihRKvGt4s6H/bujkMtRqlTMXbGRi1dvYWttgZuTQ6n+rt1xgGPnLqJRa7CxtmDEgB5YW5aeRfSg700fGQ11cbQD4GTkJSgdxxJ7N4nXW+mW1Viam1HF3YUjZ6Lo1qYJEomEwuJiNMPh4n0AACAASURBVBoNSpUKlUqNrZVFhfkszc1wsrch6soNQgNfbDmJIAgvRgSygvAf8ejuvx9mF7JuyndYmZlgYGxM65Hj9KOZzn4BTwxiQTed9UEwZeflQ05KEtQI4XbEWbp/+7N+ZO/BNOW486dRFhZw6/RxQDfSZ+vhBYBLYA0OzJ2JV+16eIaGYeHghLmDI1qNhoPzZuFaPRjPWk/+w+7RqcUxR/azZ9ZUen6vmxorUxjgU79hufkSL1/Et3EzZHI5MrmcauFNSY65rG9v2q0brP3iE0A3vdrA+MU3jfKuF45EKsXQxBQrV3dyUpIxtbIh6Uo0x3Jy9OmURYVkJdwtE8jmZdzDxNKqUnUZmpjSavhoji9bgFpZgnvN2hiYmCKVydCo1URsXkubT77A2S+ApJgr7J01ld5TfkVh9PAP/6uH9uHfpEWZsk2srMjPSBeB7L9MWkYWk8e+T2FRMUM+m0yrRnVwdbRn2vy/6NyiIS3Cw7h68zaf/vBbuflrBfnSpF4IEomE+ORUvvjpD5b89KX+fnFxCdO+GE5KegYfjp9Gy/AwjI0M6dG+uX6q5q7Dp1i0dhtjh7711LbuOnSSW3cTmTFhJAATflnArkMnad9MdxbznYRkvh39LhKJhI8mTify8nVCA32Zv2oLQb7ejBjYE41Gw0/z/mLPkTM0DKvBhl2HWTZ9AoYGCgoKizA0KLs7eFVPV6Z89iEyqZTM7FxGTppB7SBfzExNXsozHNq3KwtXb2X6+I9KXS/v2Rko5Ez9YwWjh7yJu7MDBYVFfDxpJv4+nrg7O5Rb/uMcbK35btS7KBRyCouK+eTbmdQK9MXdxZGFa7bx2zejsLex0gfuvTu2YNfhU4x7v3+5U51v3UnExdFO/zzKc/l6HLO+/hhnB7unti32bhKRV64z59sxSKVS8vJ1M0CkUilj3n0TCzNTtFotPy9YyZ6jZ2jf9DV2HjpJSloGv30zCpVazbgfZ+tfihw4cY6k1HtM+3wYUqmU7QeOM3/VVsa8W3Z2yMWYm3Rr27RSz9DH05XDpyOp5uVGSnomV2/G4Xi/zj4dW/L973/Sf9QkiopL6Ng8nOrVqlSYD8Dfx1MEsoLwLyACWUH4D9gYkcBn6y/qN2tSa7QsMWnC6F5Nef2xda4KQ6PyitCTKx6OCEqkUrQaTQW1a2k0aCiugcFl7rQZ+Rmpt66TeOkCm7/9ksaD38cjpDa9fpxF4pVoEi5FcXLlEnp890uFU3t96oVzYM4MCnOy7/fDEIlE8oQWPeVYMa2W2l164d+0ZQX9ejZlnptajVarASR0m/QTsgrO4JUbGKBSllS6PregENyCdMFwQXYWUds2YOHgRPrtWxRkZuDsFwDoXlzIDY3ITIjHwUc3ApefeY+kq9G0eH9kmXLVSiUyhWGl2yH8PcLDgpFKpZiaGOPm7Ehy6j2sLcy5nZBMs9dqAbo/rj2fsFYzKfUeUzcs515WDjKZLtDLzM7Rj3g1vj9y6Whng5mJMemZ2bg7O3Du4lW2HThOYZFu5KoyIi9fp2V4mP7c6VYNwzhxPlofyNYPDcTg/jFVPh6uJKXdIxQ4FXmJa7F32LBbN8OguESJnbUlxsZGuDrZM23eCmoF+VO3ZoB+RPFR2bn5TF+0msSUdGQyXXAVn5yGv4/nS3mGT1Les9NqtcQnpTJl7jJ9OqVKxd2klEoHssUlSn5ftp7Yu0lIJBIysnK4dTcJdxdHgv19mL5wFfVDA6kTHICTvW2F5VXmuMXq1bwqDGIBnOxt0Gg0zFy8hmD/qtStqft9o9FqWb/rEOcuXkWj0ZJXUIjh/RejF67epHl4GHK5DLlcRrPXanHpeiwApyIvcz0uno++0b2oVKs1mJqU/29VemY21k+YOv24d3p3Yt7KzQz/+hfsba0I9q+KTKabQn30bBRebs58N/pdCouKmTB9AUfPXqBhWPBT8wFYW5oTfe1WpdogCMKrIwJZQfgPmLorptSOwwBFSg1Td8W8tA2bPEPDiNq2gfD+Q3RTsnJzMDa3wKtWXaK2b8Kxmh9yA0NKCgvIz7iHpZMLuempOPr44ujjS3ZKMum3b2HvXRWpTIZHzVq41ajJ7Yiz5KQmVxjIJly+iJGZOUZm5iiLi56a1i2wJtePHqRq/UZo1CquHz+Mua3ujzOvWnW5uGsLVerUx9DUDLVSSWZiPHaeVUi5eY3Tq5bS6fNJL+WZGRib4Oxfncgt66jdtTeg2/VYKpOX6a+NuydZSYmVLrsgKxMTK2u0Gg2nVy2leou2KIyMMLOxIy/jHlmJ8Vi5uJGZcJeCrEwsHB/+cR5zeD8eIWH6nZcf0GjU5KSmYOPu8QK9Fp7Xo7Mq/LOL2H81hcH3gyoDxcN/rqVSCer7QaWE8l/mPG7qH8t5u1cnXqsVhEajofv7X1DyyBRahfzhCKdUKkWt1pCansn8VZv5+cuPcLK34cqNOKb+saLCurQAj79keuSzQvFoXRLUal1ftFr4ctjAcoOyaV8M4/KNOC5cucHIb2Yw8eO3qeLuUirNb0vXUy+kOl98OACJRMK7n/9Yqo8v+gyfpLxnJ5GAhZkps77+5LnL/XP9DqwtzPl4Qm9kMhlfTfsD5f01oF98OIBrsXe5cPUGn02Zw4f9uxNWw/+p5fl4upKYkk5efsETR2WNDEu/xJLJpPdfyOk8WINqamLM75NGc/HqTaKu3GDx2u3MmPAREZeuc/l6HD+O/QATYyNWb9tHQnIa8PRAWquF3h1b0LpR3Qqfi6FCUep7fRpLczNGD3k4qjth+gL9i4Qt+47x0aBe+pcb9UMCuXj1Bg3Dgp+aT/ccVPqXMYIg/HNEICsI/wGJ5ZwB+7Trz6PBW29zbOkCVo8djlQmw9k/kIYD3iWkU3fOrv+LdV+NRiKRIJFIqN2tDxYOThyYO5OS/HwkUgmmNnbU79Of3PQ0Ds3/Da1GjUatxqNmLRyrln/Mz4M1sqBFKpPRasSnZTYtKk9A89bcuxPHqrHDMLOxwyUgkNzUFAB8GzWjMC+HTZN0OwFrtVoCW7bDzrMKeelpyBQVr1F9Fi0++ITjyxaweuwIABTGRjR9d0SZQNbS0RlDE1N9AApwdMkfxJ45SUF2Jlt+GI+RmTm9p/wKwOk1y0i+dhWNSoVbjRDq9dat1zOxsqbR4KHsnjEFiVT3B3qz90ZgZGauryvm8H7C+w8p09bkmKs4+FQTx+/8A8rOqtAwY+91bGyfPDpmYmyEp6sTh05F0Oy12sTcusPt+ORy0+YXFOFobwPA7iO6zX0qUlBUhFwmx9rSHI1Gw/aDJyrVl9Dq1dh37CyNwmoCsO/4ORrUrlFhvnoh1Vmz/QAf9OuGTColOzefwqJiLMxMKCouoYafDzX8fLh68za3E1LKBLL5hYU42lkjkUiIuHSNpNR7Fdb5LM/QxNiQ/MKnv0R7wM3JHkMDBfuPn6N5A91ut3eTUrG1sih3NLk8+QWFeLk5I5PJiItP5tL1WJrUC0WtVpN6LxM/bw/8vD1ISr3HrTsJhNXwx8TYkILC8n/vuzraUy8kkF//XMeIgT0xMTZCrdGwdd+xJwaQTva2XI+Lp4q7C5GXr5OVo9vTIDs3D5lUSu0a/oQE+nL6whWS0zLILyzEwswEE2Mj8gsKOXgygmpeut9nNQOqceDEORrXqYlKreHgqQjsbXTLKeqFVGfz3qM0qBWEmakJSqWKu8mpeD/2HQN4ujkTn5yGjVXZ9bOPy8nLx9TYCJlMRtSVG9yOT+Kz9/sB4Ghvw/noGPy8PVCqVEReuU6DWkEV5gO4m1T2508QhL+fCGQF4T/AxcqYhEeC1tkuujfJrlalN0Pxb9KizLrI1x/ZQKn50NJrvx79bGhqVuY+gEwup16vftTr1a/MvS7jfyhzzcjcgh7f/fy07gBQp/sb+o2cHmdh78jAR6bsPUj/sE0Kmrzz4RPLrtnu9XLPm026eonQzt2f2q7ynsGjz/DxzyZW1rQcNvqpZT4Q0qkb0Xt30PB+kNlwwLs0HPBuuWkfHJtUHt/wpviGN33i/TemzS73+uV9Ownp2LVSbRVernJnVajUTN0VQ6OnvLv55J0+TF+4io27j+Dj6YqfT/mj6UP6dOa7Xxdja2VJkJ83FmYVrwv3cnMmPCyYD776CXtbK2r4enPpWmy5aTVqjX6Eqk2T+iSm3mPExF8AqBXkR5vG9Sqsb0ifzixau43hE35GIpGgkMsZ8kZn5DIp3//+JyVKJRqNFh9PVxrUDiqTf2D39vy+bANrth+girtzpY/EqewzrOLmjJuTPR989RNuzg5PPTZGJpPx1YhBzPtrM+t3HUSj0WJlYcbYoWV/TwKcu3iVAaO/1X9uGR5G744tmTb/Lw6ePI+TvS2B949R0mi0/LJwNfkFhUgkEuxtrPQbV3Vq0ZDpi1ZjaKAos9kTwMdv9+avzXsYOWkGcpluo6iwGv76aeCP69e1Lb8sWMmuw6cIqOqlDzzTMrKYtWQtarVGd1Z5kB9+3h54uDhyMuISH3z1E7ZWFgT6VqGkRDeK27ZJPeLik/jgq2nYWltSw9eb5PQMAJo3qE1OXj7jpszW97FDswblBrINagVx/lIMwf66jeouXY9lytzlFBQWgRYOn4lixMCe1A7y41rsXeau2IRMKsHCzJTxIwZhZKh7Wflun878tnQ9H46fhkajIdjfR/9z+rR8Wq2WqCs36NWh7B4DgiD8vSSVWTPxTwgLC9OePXv2n26GIPxPeHw0B8BYIeOHbjX+8bNghWcTvXsbgS3blTvyvKTmCDr+NQbb6u4vvV61UsnVQ3tLnccbNWcHaqWaWsM7kpeYwZ6hv5MWFYuljxO99z8M1jVqDce+XMbdQ9FoVGq8WocSPqkvEomEqLk7ubL8kD5tdlwq1fs1pdF3/Yg/epmtvadg5aPbfExmIKfnXt207osL9lCcU0DYx2VfOPwXVRm3rdyV3RIgdvLLP7P4ZZs4YyENw4JpER72TzdF+I8rKCzi08m/Me2LEeVu+vWqnYuO4eCJ84waUv6LVkF42SQSyTmtVit+uZZDjMgKwn/Ag2D1wfo6FytjxrTxE0Hs/6Cg1v9M0CJTKEoFscqCYqL+2MWbx6YAoDAzou647pTkFnL6x3Wl8l5eeoCMawn0PvQ9EomErW/8xPX1J/Dt3oCa77Wl5nttAVArVSwOHIZvj3B9Xms/11JB8QPV+zdjeb3RBL/dCgOLF99V+t/u8VkVj17/N0tJz2DijIW4ONrRqG7Nf7o5wv8DJsZGvN2rEynpGWVGnP8OhYVF+hFwQRD+WSKQFYT/iC6hriJw/X8i4tdtXN9wAo1KjcxQQdNpg7Gv4UX04n3cu3SHJlMHkXLuBmtajafn3kk41vLh4OiF2AV54terIXs/mE3G1QSkChnWVZ1pu6jsdOmbW07j8po/cmPddDpDCxNcGwQQf/RymbT3Lt3BvUkQsvub6bg3DeLa2mP4dm9QKl3czvOYOFjiGOpdYR9lCjkezWpwfcNJAgc0f57H9D9lTBu/cmdVjGlT/vrxfwtHOxt+n1S5qfOC8LL8k8feNKwjXtgIwr+FCGQFQRD+x/j3aUToMN3I7d2DFzn4yUJ67vkGt8aBRM7errt++BJOdaoRf/gSjrV8iD98idAPO3Bn/wWKs/Ppe3IqAEVZeeXWkXD0Ck5hVSvVHvuaVbiy4hA13m4FQOz2cxRn55dJd3n5IQL6Ni11LetGMquafo5ULiPo7VYEvNFYf8+pTjVu74n8fxHIilkVgiAIgvBsRCArCILwPyY1MpZzv2yiKDMPiVRC1k3dLqtW3k6oC5XkJdwj/nA0r43vw9mfNuDbIxx1sRLLKo4ggcxrSRwaswjX8AA8W4eWW0de4j282pR/73EBbzYm53Yq69pNxMDcGIdQbxKOlR65zU/OJOHIJVr+9p7+mkOwFwOjZ2FoYULO7VQ2dv0eM2dr3Jvqdrg1cbAiLzHjeR7R/yQxq0IQBEEQKq/icywEQRCEf8zGiATCJ++nyrhtJGUXse9yMjsHTafh9/148/gUOq0Zh7pYqU/v2qg6cXsiKUjNwTU8gPyULG7vicCtUSAAll6O9D05FfemQdw9FM3KxuNQFZWUqVdubFCq3KeRSKXU/6IXfQ7/QLdt4zFxsMTat3RAdnXlETxbhmBs+/DIDAMLEwzvr3+18HTAu30YSaeu6e+ri5XIjV7ucUiCIAiCIPw3iBFZQRCEf6myZ4tqmbnvBn1K1Ji72gIQvXBPqTzuTYI4+d1qPFro1nE51/Pl3PTN1P+yFwB5CfcwtDbDu0Md3JsFs6j6hxRl5mPmXDpgtA1wJ/N6YqXaqSoqQV2iwtDChNz4dC4u2EO7Pz8ulebKX4do+O1bpa7lJ2di4miFRCKhKDOPOwcuUv+Lnvr7GdcSsA3yrFQbHvfZjP7I5QoUcgOUqhKqeQTxZvvhyGXP98/eok0/4elcjeZ1n76L8vHI3fi4V8fR1u2Zyi8oyuPwue20De+lv/bTkjG0fq07wb71n6vNADFxUcxc8RWOtg9fLPRq/R7+VUKeqS2v0qpdc6jqHkjt6o24m3yTFdt/5U7yTWpUq8PQnl/p0xWVFLJi+yzuJN9ErVbRKLQtrRvofl6KlUUs3TKd+JRbaNHiau9F/04fY2RowvHI3azaNQdbK93GQHZWTnzQewIAa/fMx8PZh7pBzf6WvgqCIAgvjwhkBUEQ/qUeP1tUqtWQh4TIBqGsbvEl5m52eLQsvfGIa6NAcu+m495YNwLr1jiIS0v260dk712+y/FvVgKgVWuo/XFnzJyty9Tt06kuB0cvpN64HoDuiJ0lwSNQlygpySlgUeAwqvdrSr1xPSjJKWRDp0lIpBIAGkx4A4eaVfRlJZ2MQZlXhEfz0m29ueU00Qv3IlXI0ajU+PdphHf7hycM3Nl/gfpfPH8wNbTnV7g6eKHRqJmyeBQRV49SJ7Dpc5dXGcej9mBmYvFcgeyu42teSfDoYu/BF0N+/VvaotaokUlllU6fmZPGldgIerXWTTk3N7WiZ+v3uJtykyu3zpdKu+PIX8hlCia8N4cSZTE/LhpJVY8gvN0COHJuOyq1iglD5wIwd+23HDy7Vd+HAO/QUkHxA20a9GDK4lGEBTZBKhGT1AThVdl9+izzt25Hq9VSrFQR4OXBj0OHPDXPpdg4lu7aw+QK0uXkF7D20GEGt29bYTu++3M5kddvAHAzMQk3e3sM729UuHLiV4QOfo+Tc2ZhYmRUyZ6V78D5SE5cuszn/d6kRKlkxIzfuBx3G4DDv/5SKu38rdvZduIUarWGGj5VmDCwn/5c7vlbt+PbtWdg8MAhV4FTwLsXFs8rDh44pAfw5SPFuAGHLyye1y144JAgYMqFxfP+89tri0BWEAThXyrxkeNYTAsKMShRkWdqzD4/X+ZveDji+ehZq2bO1gzLWKH/XK1rfap1fTii59kqBM9WTx6Ne8A+2AsDc2PSLsRhH+yFVCZl0KXygyETB0v6nvrpiWU51/dj0KXfylwPHtKG4CFtys2TeS0BrVqDc90X351UqVKiVCkxMTIH4MqtCDYdWIJSXYJao6Z9wzeoG9RUV29OOit3/k5qhm40um5QU9o17FOqvKuxkazcNZsh3T7D1cFLf/1Y5C5uJ15j5c7ZbDywhB6thuDvVZN1exdw6abuXPRAnzC6t3wb6WPB3ortv1FYlMc3c9/HQGHIuMHTAbh2+yI7jq0mO/ceYdUb063l2wBk5d5j5c7fychOpURVQt3AprRvVPlzLdOzkvlu3nB+GbOmzOfy2vLZjP4Me+MbfX8f/fzZjP6Eh7bhamwk9tbODOj8Ccej9nDwzBY0WjXGhqb0bT8cJ7uy5x8fi9xN7YBGSCS6lyBW5rZYmduSnH6nTNq7KbE0CGmFRCLB0MAIX89gTl3cj7dbABKJhBJlMWqNCoDikiKsLewqfA7mplbYWTlx9VYE1X1qV/r5CYJQeWlZWXy3dDmrvv4KJ1sbtFotMXfuVpgvsIpXhUEsQG5BAYu376pUIPtF/776/287ahzThg2lmtvL35tg1vqN/P7JCACkUikD27XGysyMd6eWDmKPR19ix8nTLB//OcYGBkxctJSlu/bydsd2+ns3tm68EvjmgNrAH8DHwOQLi+etBdY+KCd44JAIYAXAhcXzooMHDikJHjik2YXF8w689M79i4hAVhAE4V/qwdmiodFXCbl0nYP1a6GSy3H9m84WbTJlIFm3krHH62+p71G5CRk0/WnwC5Xxf+zdd1yV1R/A8c+9l8veU/YGFUFR3HvkzlG5KnOglqVt0x/ZsIysLCvLSqMszZ17a+beEyegIKiAssdl3fH8/rhwBZm2y/N+vXrFvec855znQYXvPed8z9er30VpZExGThpN/VoSUh6oeLkG8Nq4j5HLFeQX5jB70RRC/FthYWZFzLoPCA1sw+Thb+rHUZRXpc1j5/ew+9g6Xnj8vWqBUscWfThybneV5cB7T27ixu1rzJykD+Q//2km+09vpVvEw1Wufbz/c7y3aCpvPv1Vlfez8+4wbexcSkqLeX3+WDqG98XFwZ3v13/EgC5PEOQdikar5pMfp+PjFlRjMJaakcI730wGwEihJGrC53U+t9rGUpe8wmxeHaPPhJ2QfJ6TF/czbexclEbGnE84wQ8bP2H6+HnVrou/HkvvDo81qA9v1wBOXzpAi+AOFJequHjtlGHmu0urAVy7eZlXP9Z/6NDUvxVtQ+9mu45PPs8730zGzMScPh2GExbU1lDm79GEK0lnRSArCMC7+39FrdOh1elIVxXibqXPa+BtY0NkeEQ9V8O1nGz2JCUyseXdupl5+RgpFNhYWgCQnJdLgfLuh3kzvl7E9fTblGk0eDk78U7kWKwtLDhxOY6PV65mxdszuZWRyahZ7/FYty4cjD1PcVkZs8aPoWVQINFLluEYGsyI9z/AWCsxbeJY1l25xI38PPr4BzKsaTNDXzklxfxw7gzZxcU4RoRyMTvTEMjmlBTj374V03Zuo7C4hPzkmzzbvQcPtdb/27Dq9Cm2XU1AJ+lAgicCm9C7VTjLL8QSYG9Pazf9v0en4uKxs7Skkb09AEYKBe1CmnIrI7Pa84pLuUnLoEDMTUwA6BTWjAXrNxI5sJ+hbK1arYtdvEgKGztxGzALmFO5jbCxE1sCnsDGSm8vByYAIpAVBEEQ/noVZ4ueadaYM80aA3/t2aK2/q7Y+rv+JX3dy6t76H1fs/7MLcPxNV3Ni+nZ9TlGd22LWlPGV6veZffRtfRq9wiFRXn8sPET7mTfQi5XoCou4HbWTdycfUi8eZmXRt/9HcHK3Mbw9eFzO1EamfDy6DmYmVg0aEyXE8/QoXlvjBT6ZWIdWvTmzJVD1QLZ2rRq2gW5TI65qQWujp5k5KRia+VAXHIsBdvvBtklZcWkZd6oMRi736XFv0X7sF6Gr8/FH+Pm7UTej6k4n1hCVVzzMU85BZlYW1Rf2l6Tvp1G8POub4n+dgqW5jYEeYdRWP5BQ8Uy5I9eXg7At2vnsPPwanp3GEZoUFsiQrpirDQhJe0qny17nVef+ghXJy8ArC3tSUg5/1tuWxD+c97oot8vnlmkYtb+X3mnW8/7ut7fzh5/O/sq7wV7etDM15c+r8wgonEQLn7emNnb0tpNH0BOf2Ikdlb6FTPzf17Hd1u28+LwR6u1nVtYSKi/L88/NpQth4/y6aqf+XHmDJ4YPIBP9/7Kyv9NByC9sJBxLVpy7NbNam3og04HBgYG03/GTPbY2tA1KAg7UzOWX4hFlZVDJ/8g+vfux8w9u/ho9c881LoVsampbEmI4+3uvfB1diYlM4Px0R/RrnEw/QOC+ODwASJc3ZHJZJy8Ek+on2+1vmvS1MeLtfv2k1NQgJW5OTuPnyQtM6tKmZGZmVHY2IlGwHCgpsQR44GlsYsXVc7ceAT4rEGD+BcTgawgCMI/lDhbtOFqSoz16e4ErKw9GBLuTlhQG2Ljj9Or3SP8tGU+zYPbMXn4m8hkMmZ+MR61pnrm5nt5uPiRkHyetIwU/DyaNHhsFctma3tdF6WR0vC1XK5Ap9MiSTpkyIiaMP83J69SyBVIks7wur77l8vlddY3Ma68SkCiY4veDO4+pt5xVCTjaggTpSmP959ieP3T1vm4OuqD0X2nttA+rBdKI33SsoiQLhw59wu9Owyr8mGEl2sAAZ4hJKXGGQJZtabMcJ0gCLX78sQx2nl40MrVnc3xV9h+LYHP+w5ELpMx45edvNyuIxlFKtZeucgbnbuz4mQS6xLOo0OL0tWdToHBBCtl7M3PQnerkNf37KKZswvqm+lsi43FyM0ZSSbDWGlE7G39sXIyEyUvbN9CSycXmnRrj9xe//c5LMCPuSv0WyNO3EmjMO2OYZyNLC3176feQidJVe7hRl4eAwL1Hwbr1Bqczcw4kXqL3n4B3MjLI+92Jn3btsbG1BQfO3suW5lTWqZm/aUL3I5P4rULd1eqyIAbd+4Q4uuDnakZV7IyaeLoxO2cHHxdGzXombZt2oQRPbvz9NxPMVEqadukMUYKRZWyuLi4QGA/8AtQ5TiBsLETTYBRwL0Z69IBl7CxE5Wxixc17AiCfyGR2UAQBOEfbEi4O4dm9CBpzgAOzeghgtha3JsYC6BUo+OjHXHoJB3xyecNmXuLSgtxsHVBJpNx6dopMsr3w5oam+Hn0YTdR9ca2qi8tNirUQCTh79FzLoPiLseW+M4TE3MKS4tMrxu4hfO4bM70Wg1aLQajpzbRRPf6ufzmpmYl+/x1FYrq6mPQK9mbD+00vBedt4d8gobfuautaU9Wp2WO9m3ADh+/u7qs5rG4mTnxvVU/dFIlxPPkK/KqbXtsKB2HI39hZz8DAB0Oi3JqQk11nV39uV2VvVZk5oUl6ooU5cCcPN2ImeuHKZba/3MtqNtIy5eVloppQAAIABJREFUO4UkSegkHRevnsTdWT9xkZN/dzlfVu5tkm5dwcP57mxJemYKHi5+DRqDIDzImjo5cSlD//f6UmYGjSytSM7LJau4CK2kw9ni7kqV9WdusfDYBXIKdJw4Z8zh00o2Hldj49iYsRGt0eQV0N3agSClKasPHMQvojlfPDacUX5BSMlpLD53mjKt/t+g/LJSXC0sSDt5nq7e+r+7cpkcrU7/4VpSXh4leQUNugdvW1uO3byBJEkoTE24pSokq6jIUGbv6YqxkRF3VIUk5WZjbG6GVqclR11GI1cXWvbpRtNenRjz1Eh2ffIhIb4+AATY23MpQx9MmyiVlKobHjs+2bsXq2a9wZKZMwj0dMfPzbVKWcKGny/HLl7UATgPXL7n8qFAUuziRff+UDIF1P/lIBbEjKwgCILwH1A5MVaF5iZb0ZUomPXVctycvRnYRZ/k45Ee41m27Qu2H1yFu4sv7i53g5rIodNZtu0Ljny1C7lcTptm3enbcYSh3MPFlymj3uHLFW8xqu9zhARU3TPWpWU/Vu9axM4ja3i01wS6tOxPRnYqsxc+C0CIfys6t+xXbawWZta0De3OrK+fxtzU0pDsqTaRj0xn1Y5vePtrfbZfU2Mzxgx6GRtL+zqvq6CQKxjRZzLzlv4PBxsXgn3uZpSuaSxDuo/h+w1zOXB6GwGeTbG3ca617SDvUIb0GMsXK95GkrRotBpaNemMt1tgtbotm3Tk5MX9dGjRG9Annfrw+1coU5eg1qh5bd4TDOo2mk7hfcnMSeebNe+hkCswMjJmwtDp2Frpj6Ea2PVJlm7+jLe/ngSAp4ufIfnV3hMbORt/xJBNeUiPcXi5BgAgSRKXk85WS+glCP9FXzZ5jWFrnsc5pHpW9cpbM9xszXiup4+hbGnfD2n7Qh+adPZjZ+JV1Fot+aWlPOTnz6WMO1ibmNDE0alKex/tiKNQC02DdPh7lpCfU0pmoTUf7YhjxiBnyjQa3J0cuZ2dg5WjPTklxcw9cpCbGZng5QrIyC9frWGiUBDioG8/2iKSV29XTR5YoC6jqFCFRqs1zGYu372Hc/m5tGpcNWHg483CWHYhlrf27cHa3wtvK2sUcrmhbNvR47x/5CBOlpY0cXTimi5OPwalkmIkutk5odoYzzrzIxy8vAnvI1mYWpvDhFZoQvVjDPRw53R8zR/e1SQzNw9HWxvyVSpitmznmUED9feVlsOS0fORAWFjJ9rZ5ElLzIqZVv4cFgO9HLvLrD1uSSXRFpEHgW+iVDFLypttAsRGW0TKgN1A8yhVjGP5tf2BwVGqmKdrG1O0ReRg4KEoVcyUaItIE2ADEAFQ0U6luv8DnkAfVx4DJkWpYkobUOYDLAD8AS3wcZQqJibaIrIZ8GGUKqberMsikBUEQRD+9SoSY1U4UDIOAHdbM5Y/26NK3ab+rZg95fsa27GzduS5EW9Xe3/c4FcNX7s6etV6fVhQu2rnvg7r/TTDaqxd1VMPVz17tyJ5Uk2vbSztmfjo/+ptM9inea37YzuF96FT+N2s0Q93vXvO771j8XEPZtaziwyvh/W++/vP+y/8WK3ttqE9qiRbqk3zoHZs3r+M3IIsbK0ccLRtxIcv/VRjXc9G/sye8l2NZVbmNoYEXfca2nM8Q3vWnDjs0rVT+Lo3rjMwF4T/unu3ZtzKLebD7VdoG66rUq+RpRVlWi3Hbt0k0N6BECdnvj97BmsTE8Jcqi6lTc0tRkLOyXPG2FuX4OZUhJdbCVcOX+SnXd4EBvrRxNuLQA931p45TVZmNqVp8YT6+HAhMYlP/jeKE5fLg0ijusMVpVzOQ20ieHTm21hbWLBk5gwSU9MwsbeuVtfaxJRnWrUBoO+mGZT5euNmaWUoSzpxjuWREzA3NWXukYOUFOj39ztZWNCqZUsWbdxCWlIapn7uOHZwInrBy+QlZ/HlF2uQFRdCy9Z0bdGcRZu3otPpkJcHyaNmzeZ2di75KhW9XppGx9BmzBqv334xae48JJ0OjVbLyF496NFKv2rn4JzNbGlcSKD18BDgmE+yVNgkjj0V95LhwNeZjrL/ZTrKghrH63yAldEWkU5RqphPgD7Az8AU4Dpg+LQyShWzNdoi8t1oi0j/KFXMtVoe62yg4lNXLTAXyEQfFBtEW0T2Rr+0uS1QRKXMyvWUyYB1wKwoVcz68tdO5eO7EG0RWRZtEdk9ShVTZ7IqEcgKgiAI/3oVibEqLy/+KxNjCb+NXK5g9IDnycpNN8yu/pWKy4p4tPxII0F4kCzt+yGuLX24dfwa8ZfTCfVz43hHfXZf2+x8uuy+QKF/GBvGL0JTcnd1aoC5DcsOHcfnl1TWnVtH2mvh3LQ2ZmRIKF82eQ3b8W3JtCnh8aXHie0QxAV/b25nm6FL1dCsk4L+e+U4aDSUlE8KGykUOEUdQ7OgN4FnszD58QSvvTeMxJxsWjcJ5vn4rnyfmczuEQuJ7tOD/awHwN3JkeVjprK034cYD3LD/tc7fDz+MQL6Nic3OZO9P++nd7+HiD10kKxtyxiwYByeHQIpLCvl1u7LHIreSE8PB67dzMTXPhC8IOFYPK/eCWRFzw/J8bHkxogAdr71BkqFgnYenlzOzCBmxqvsi97ADjcN/btFIJfLsfN1wmFQKMmf/krJqCLsLCxwuqFhZr8ofLKUuLXyZen8GSiMjVgY8QYDvxmPWyv9SqBjn+9gQq4v/b+omlNAU6LmyrqTbIifi9LM+KIkSRHRFpHXK9dxyiI3dvEi/XruxZyNtoh8Afihw2MTvsBS9kjb47pJwDxgLDCYqlahTxL1+r1/NqItIjsDmVGqmJsAUaoYDbC7fAb1Xs2BA1GqGFX5tZUzK9dV1gsoiFLFrC/vQwLuVGq3QVmXxR5ZQRAE4V9vSLg77z8SirutGTL0M7HvPxIq9hT/C/i4B+PvGfK39B3RtMvfEkALwj9B/s1sRu+czqrh3Wl86TrWufrZx+47TxIf7EWZiZKIZ3qQdirJcI1qzXlKLBQ8u+AZxh96E9OEHEzKJGxMTQEoyVXh2MSN8B+eJUCbS9uQElqHlRIWrObWFei4+kUmfTKBrPRsonZsZ/mFWBQFavrnWFA6pTUpH3blsztX2Bh/BdWdfPbNWoeprTlj9kShUN6dfyvJLWL78z8y5LtJ9HuoDa7TerBt6hJKcou4WpiLz5AuXHVTkNnZjYtvt+HnhVsBOHPhGp+kXeTKzNZoprRhRr+HcPRzpiS3iPVfbOLCC6EkvNuO4sjmuM09ibZAvy+/vYcXZkZKZv66mw2BOuyKJDp66vfhS5LEdbUK28s5ZCekI1PIef+DV+j49lAmnngHnVbHuR8PAhDxTE9OL/zVcN3pb/fSalL11Supp5Kw83PGyFRZrawOxwBnuxzCZTrpdd9kPgSe454EUeWOALWlpO5W3lZDnAIeiraIdIy2iLw3s3JdZU2BrGiLyNXRFpFnyv9f+bDxusZnIGZkBUEQhP+EIeHuInAVBEFooMZDI5DJ5Ti5WJNjZ4V1XiHF5ibYZ+VzxcMd9wRz3B/1x6l8T22ZqhTNd6focMSNFdH63EIehSW0ftbL0Gbvge3xbK/fD39nkR131t4hztGOR1YeoKmPE5mbL7IWaJxXRK8PRhLcLIxooMfgDgx0tEKn1THHeiJTskaQ+MtFvNycmTFAn9QtfHxXfn1jDQA3j14lNzmTFUM/RWMi5/xof4KUMnIS7xDgYEvwjEO8ensBADmJd/jxpX0AmJ1I5+EzpQyMrJqr4Or2WOS/JBGUcDdpVHF2ETmJd3Bt6YNcJuOJUP3q3P3vbUBdqEZenoE+9k46QQ4O5Obp9/RKOon4mEOk7TzPt9otlOQWoTTXZ0YPfbw9B9/fSHF2Iaknk7BwtsYlzJN7FdzKwcK5+tLoesgAOh6VkoCuwP4oVczZWmZS04Hqm6X1PIArDekwShWzJ9oi8ktgJ1BCpczKdZWhj0F7AG2jVDFXoi0iXwZ+KH+vYnwu0RaRyihVTK0Jq0QgKwiCIAiCIAj/QZWTOD2RV8KeK3cYWR6YVsz2TesTzJ7vdyLX6Y+qkWQ1b82QdDqQwbgDM6vMjtbG296c1qGe+HRtzMp9p5ly7r1a61aMRa7QLxbVabRwz9E5VUk4N/Ng9M4ZAJy/cxvHEYNwtbIiNzkThcndmUyZQo5OW77ft9Y2q7Z3P0o0WnqYOLOyqAyHIFcurjzKjSMJjN41HRMrMw59tIXsBP1xQkpzE0KGtyV2ySGSD8TVOBsLYGSmrLKku4Fao1+emwF0AcKiLSKfQh/v2ZUvTQ6LUsXko89qXD1Lol5xeXmDRKliPqP8zNpoi8jhVMqsXEdZMnAqShVTETAvBd6p1KwpoK4riAWxtFgQBEEQBEEQ/nMqkjjdyi1GQn++9me7E1h/5laVekPC3fFztMDBwhiNsZJCZ1umW0oMCXcn9WQiGRf1R2SZWJnh2SGQIx9vM1ybfzObwvS7x5SdX3oIAFVGAdd2nse7czAOQY0wMjfm/LLDhnqZcWmU5tcWR+m5t/HndmwK2VdvA3B28f67ZW0DyL56h+v79HFQqLMLUnwmUp3BL/j1asa1HecNbWpK1ZQWFFdrD/TLe+trDyBYY8qB53+i5cRumFibUZJXjLmDJSZWZpTkFXFx5dEq9Vs93YPjX+4i/cx1Gg9pVWObziEehuC3IaItIsOAT4EPolQxUpQqZmCUKsYrShXjA3QCcqJUMT7lQSzosxqfq6W580CDE0xEW0Q2Kv+/HTADfWKo+sq2AZ7RFpEVZw31vWc8TYCaz7mrRMzICoIgCIIgCMJ/TE3na5dotHy0I47J99R1tDLhw2HNCezXnIwx4Wx55jtiNp7ANdwb9zb+hnqDv5vE7ukrWNRanyXc2MqUAV+Nw7KRDQDWng78+NAcVOl5dHi1P87N9LO/w1c/z67XlnP00x1IOh0WTtYMXfJMneO3cLam3/ynWDXsc8zsLGjySGtDmZmdBcNWT2XP66vZ/dpytGottj6ODF/zfJ1t2ge40P/LMax76mskrQ6ZQs7DCyNxbuZRe3vlS4grO7/sCNf3XkZdXIaJlRkhI9oRMVm/pTP08fYkbD7Dwog3sHK1xbNjEJriMsO1tj5OOAS54tbaF4VxzaGYnZ8zJjbmZMXXGczOiLaInACYo5+JfT9KFVM9jXzNKrIa12Qz8Hq0RaQ8ShWjA4i2iDyBfsmxXbRF5E1ge5QqZkJ5/V3RFpFyQAl8UZHAqa6yKFWMKtoiciqwrTxjcRb6pFQNGZ+BrCGfNPwdIiIipJMnT/7dwxAEQRAEQRCEfx3fGVuo6bd8GZA0Z8Af3l9d59QKd5XmF/NN+OuM3T8Ta/faz/6+uOoYt45fo8/HT5ySJCmi1or3Kdoi0gHYA7SOUsWU1VLnG/TB6ro/qt+GiraINAaOA72iVDGZddUVS4sFQRAEQRAE4T/Gzdbsvt4X/nynv93LwlZv0Pb5PnUGsQAhw9tiH+BC9fng380PmFxbEFtuJvB3/UHxBqLqC2JBzMgKgiAIgiAIwn9OxR7Ze8/XFkeT/bvIZLI/dEb2v0TskRUEQRAEQRCE/5iKYLUia7GbrRnT+gSLIFb4zxCBrCAIgiAIgiD8DgVFhTw+ezID2vXimUFjDO9vObKLUnUZj3Spf09qevYdxn/4Ij4ud88Vfazrw/Ro2ek3j+u3nq9dplGzeNsKjlw8gUJhhInSmCd6PUqHZq3rv/g+vfPjx4zoPoRgT39OxZ9j8baVXE9PYVDHPkwcONpQL7sgl89/XkR6dgZanYaRPYbSs2Xness+WvElSWkphnaS0lN486lXaB8SwbdbfsLfzYfu4R3/8PsS/nwikBUE4YH11srPMFIYoVQYodZq8HfxYkTH/ijkir+k/8+2/EDP0PY08wr60/pISLuORquliYd/rXVik+O4ciuR4R36odZqWLRrJSmZqQDMeXJalbo7zx3k5NXzaCUdPk7ujOw0EKXCqM6yrIJc3lk9H1c7Z0M7U/uNxsLUnIs3EjifHMfITgP/+JsXBEH4i/x65iBNvALZe/Ywkf2fQGmk/3dxQPuHar1Gq9OhkFdNV2NpasGClz74zePQarUoFL//Z9gX62IoKS3hm1fmYqw05nr6DWbGvI+VuSWhfk1+d/sVrqQkUFJWSrCn/meUq70LLzw2kYPnj6PWVN3CuXDTjwR6+PH22GnkFuYz9fP/EebXBCdbxzrLpo18ztBGYmoy0xe+S6vg5oD+g4JXFrxF1+btkctF6qB/GxHICoLwQIvsMQw3e2d0Oh2fblnM2etXaOUXUqWOTpKQAbIaUvD/k2l1OhLSrlOqLqszkN186lcm93kcALlMTo/Q9liamvPFtiVV6l2+eY1T1y7wyqBIjI2ULD+4mV8vHKV38051lgGYGZsyY+jT1foO8Qxky6m9ZORn42Rdd+ILQRCEf6odJ/YyYcATrPx1A0cvnaRzWDsAluxcTUlZCRMHjmbnyb3sO3sEG0srUm7f4qVhT+Pv5tOg9uNuXOOrDYspKSvF1NiEyYPHEuzpT3r2HZ7//HUe7tCbM1cv0DO8E71bd2fx9uWcjDuHXC7H1d6FN8e8AsDqvRs5cP4YWq0WRxt7XnhsEvZWtlX6up2Twf5zR1gS9SXGSmMAfBp5MrLHEH7avYY5k95g58m97D1zCEszC67fvomlqTkzn3rZ0FZD+gHYeuwXure4Oxvq5tgIgCMXT6K+p25iWgpDO+tntm0trfFz9WH/uaM82nVgnWWVbT/xK93DO2FspDTUdXVw5uzVC7QMCmvQ90L45xCBrCAIAqDWalBrNZgbmwKw9fReMvJzKFWXkVmQw4sDxrDj7AGupqeg0WmxNDHjic6DsLey5acDG3G3c6Fbs7YApGbfYeHuFbw1bCol6jLWHdvJrezbaLQaAl19eKRtb8Mnv1fTk9kVe4i8ogLCfZsyuHUvAPKKClhzZDvZhXmotRpa+YXQp4V+mdS6YztrHEdWQS4fbVhEl6atiUtNoqVvCAevnEKSJP1rvxBDYFnhanoylqZm2FlYA6CQy2ns7kdWQW61Z3Qr+zb+jbwwKf/FpqlnAFtP76N38051ltUn3LcpR+PP8nBEj/v+vgmCIPzdElOTKSgupEVAM3IK8th5Yq8hkL3XxetXWPDSB7g5NKqxvLBExbPzphtez5k0EzMTM2Yv+YSXhj1Dy8BQziScZ/aST/jutc8AyC8qwMvZndG9hwGwdNca0rLv8MULc1AaGZGnygfgl9MHSM1M59Pn3kUul7P5yE4WbVrC9MenVhnD9bQU3BwaYWVuWeX9xl6B/LhjteF1/M1EvnrpA5xsHfl0zUI2HtrO2L4jG9wPwPlrlxjW9eH6HjEAge6+7Dt7mCAPP27nZHA5OR4Xe6d6yyqoNRr2njnE+5Ner/J+E68gEcj+S4lAVhCEB1rMntUoFUZkFuTQ2N2vyszltfRkXhsyCUtTcwAeat6JoW31Xx+OO82GE78wrsejtA1szs9HdxgC2aMJZ2kb2ByZTMa6YzsJaOTN450fRidJ/LB3LUfiz9KxcUsAsgvzeGHAWErVpcxaNZ/2QeE42ziwZN96+rboQoCrNxqtlvnbfsTbyY3G7v61jgNAVVqMi60T/Vt2K39dRKm6jKFte9d4/1fTkvF2atj+KU9HVw7HnaawpAgzY1POJF4ipzC33jKAEnUpH25YBBK09AuhZ2h7wwy3r7MHG07sbtAYBEEQ/gnWn7llSKLkqzxN+4BwZDIZHUPbsGDD92TmZeNoU32VSYhP41qDWKh5aXFSWgpGCiNaBoYCEB4YipHCiJsZqZiZmGJspKRL8/aG+scun2bSwNGG5c025R9UHr10ioSbiUz57H8AaHVaLMp/vlXW0PNMmnoH4WTrCEBjrwDOJJy/r34AMvOysbW0aVB/EweO5ptNP/Lsp9NxtnWkeUAIRuVbgeoqq3Dk4gmcbB2qzYLbWdlwPulKA+9a+CcRgawgCA+Uyr98PORXQpdm/XmyQyhqjYZvf1nFrxeO0r2Z/pP0pp6BhiAW4NKNqxy4fIJSdRlaSWd4P6CRN6XqMm5l36aRrROnEi/wysDxAJxPiSM54xZ7LhwB9Ak0KmY/QT8bKZfJMDM2xcXWkcyCHGzMrUhIS6awZLuhXqm6jPTcTBq7+9c6DgClwoiWvk0b/DxyVfk4l/8iUp9gN1+6NGnNl9uXolQYEeTmizxVUW+Ztbkl7458CSszCwqKVSzctQJzE1M6BLc0lOeWzxgIgiD801U51kbSIi+9yrGLSTw26yTmxgq0Wi27T+1jZI+h1a41MzG57/4kJGQ1nCZa8WGgqbFp1a0vtUSikiQxqudQ+rTuXmd/Po08Sc1Kp6CosMqs7JWUBHxdvQyvjZVKw9dyuRytTntf/ejbMKZMc+8i4prZWlozfdQUw+s3Yubg6exeb1mFHSf20qd1t2rtlmnUhtVEwr+LCGQFQXhg3HumnlYn8enuBCzN7BkS7k4zryAupMQbAlkTo7s/pLMLcll7bAevDp6Ao5Udibdv8MPetYbyNgFhHEs4R6CrN41sHKvsBZrYawSO1nY1jqkiURLo96fqdDokSUImg2mDJ1RLPFXfOIyNlPe1l1dppESj1TS4frdmbQ0zz6cTL9KoUhBcW5lSYYTSTH+fVmYWRPiHknj7hiGQVWs1KCs9a0EQhH+yj3bEGX6OWHGDMqxJkffF3cSMQzN6cCk5nrkrFtQYyP4Wnk7uqLVqzl29SPOAEM5dvYhWq8Xd0ZWs/Oxq9ds2bcm6g1tp7BVoWFpsY2FNu6at2HBwOx1CWmNlbkmZRs3NO6n4uXlXub6RvTOdw9oxf+23vDriWUOypxV71vPayCnV+rtXQ/sBfdB8MyMVh1p+RlaWryrAwtQchULB2asXSEpP4fXRL9VbBpCRm8WFpCvMqGF58407t/CrFKAL/x4ikBUE4YFR+ZePCqUaHR/tiGNQCzeupiXjbONQ47Ul6lIUCgXWZpboJImDV05VKW8T2JyPN8WQmZ9Nu6AWhvebeQWxK/YQIzr0Ry6XU1hSRIm6FEer2n9omxqb4O/ixa5zh+gb3gWAnMI8FHJFveOo1pbShFxVQa3lbnbOXL2dUmv5vfKLCrE2t6SotJhdsYfo26JLvWUFxSrMTUxRyBWUadScT4mjmefdTM3puZm427s0eAyCIAh/p9TcYsPXNtI18mW+Vd5v6h2EJOk4n3i5wW1qdVrOJe0nrLE5i3fPQZIkfBs1pXPIQJRGRswc/XKVZE+vj37JsHT4XsO7D+b7bct57tPpGCmMcHN0Yebol+nVqgv5qgKmff0OAJKkY2D73lUCzLWHF9Ij7BGmDo3k+23LmfTxqxgpjDA2UvLMoDGE+de/4qch/VTo2KwNx68c5VzyVgAKivIpLCmgpFQHSLy44BidQiNwtLXDQunFVxt+QC6XY21hxaxxr2FqrJ/hjrtxtdYygN2n9tOuactq+34lSeLs1QuM7DGk3vuqoNaUsfLAfEZ0noLSyIQTCb9y/voRcgozGdIuEn/XuwkjU7Ovszd2PWptGQq5EQ+FD8PF1rPOMq1Ow0975xnaiPp6fLOP172kAZxfGTov++N1L+0Fxr0ydF5Sgwf9HyWTpIauhP9rRURESCdPnvy7hyEIwn+I74wtVVZc9fQ5j06SoZXkBLtY4GrnzMiOAzA3MWPr6b3V9pauObKdCzfisbOwIcDVm+MJ55g14gVD+fxtS0jJSOW9x182ZEQsKStlw4ndXEtPAZkMI4WCR9v2wb+RV7Xjdyq/zi8q5OdjO0jLyQDAVGnM450H0cjWsdZxVCR7qnxkTmZBDjG7VyMh1ZjsKb+4kE82fcebw6YiL5/J/WjDt+Sq8ikoUWFjZkkTjwAe76xPxhG99mskSUKr09KlaWu6hbQ1tFVb2dnrl9l6ai8yuRydTkuIZyCDInoaEl79tH8jwe5+RPg3+13fX0EQhL9Cxzl7uFUpmK3gbqufkf0ttp5cikarpm/LURgrTdHqtFxMPkZjz1YYG93/cuQ/mk6nRf4nHE2nKinilQVv89nU2ZgojbmQfJzE9IsMajvOUOfw5e2UaUrpFjr4D+//ZNw59pzZz2sjq8/U1uZ4/C9IkkTbYH1yxvScFEyUZuw8s5KIgO6GQFaSJBZun8WA1qPxcPTnZmYiu86sZGyvGQC1lt27qqr38HY3+oxqH/vK0HkDAT5e99IQYOgrQ+eN4QEnAllBEB4Yf8YvH/8FKw5upolHAM19Gv/lfatKivh82xKmDZqA0R9w9qEgCMKf7d5tKgBmSgXvPxLKkPCGJc+rLKcwgx/3zOXpvm9halw9KZJO0rH/wiau39YnJPJxaUyXZg8jl8nZfmoZCrkROYUZFBTn4mbvQ99WjyOTyYhNOsypq/tQKIyQJImBbcbgYOXCoh3v0NijJbeyklCV5NPSvwvh/vqs+It2vMPQ9hNxtHZl5YEvcLP3JT0nGYXciCHtIll7ZBElZSo0WjWN7Lx5KHwYCrl+ZvhY3G6u3DyNDBlGRsaM6jKVdUe+pZl3G4Lc9SuVEm7Fcu76IR7rONlwf6fjY3GwscfbxaPWQDa78A5l6hJyVVnYWjjwcJuxKI2M0eo0HLy4lZtZ19DqNDhau9KrxTCMjUxQlRSw++xqclWZAEQEdifEq7XhPpt5t+N80ika2bmh0ZXWO84K3+6czfBOz2JtXjWZ18oDX1QJZItKC1m0411eGHQ3edf8TTMY3uk5rMztai1zsfOs0u70L8YUO7vbP/nK0HlrAT5e95ISuAX4vzJ0Xu1Lrh4AYmmxIAgPjGl9gmv85WNan+C/cVR/vwGtuhOXmvi39J1ZkMOIDv1FECsIwr9GRbBakTjQzdaMaX2Cf1MQC3An9yZ2lo41BrEAsUlHyMi7xege+rNg1x5eSGzSEVrGv+05AAAgAElEQVT46c9fzcxPZ1inychkMpbsmUtyRjw+zsHsu7CJMT1fw9rcDo1Wg1QpOaCqpICRXaaiKilgya9z8XD0x8nGrVrfmflpPNrhaeRyBZIkMSBiNGYmFkiSxPZTy7iQfIzmvh25mHyca2kXGNnleUyUphSXqpDJ5IT7d+ZE/B5DgHg26SDhfp2r9NGQY29u59zgiW4vY6I05efDX3P5xinCfNtzIn4PJkpTnuim3w+7/8ImjsftplPIAPbErsXRuhGD242nsCSPpXs+xsXWA0dr1/JnkM+kfvrMykm3L9c7ToD8ohzUmrJqQWxNzE0sMTO24GrqeQLcQrmWdoEyTSn5RTm42HnWWVYhPScFS2tzJbCp4r1Xhs5Tf7zupQtAR2B79Z4fHCKQFQThgfFH//LxX1GRgOnv0NCjfwRBEP5JhoS7/2E/O+pbG5mSEU+IVxvDzGeIVxuupp03BLIBbqEYKfTbWZxtPchTZQLBeDkFsuP0cvxdm+HXqCm2FneT84X66Ld+WJha4efSlBuZV2sMZJt4tjQsKZaQOHn1V5JuX0aSJErKigz9JqZforlfR0yU+rPYzUwsAPBxbsze2PVk5d8GGeSqMvGrtIe0oXxcGmNqbAaAq523YZb1WvpFStUlxKeeA0Cr1eBko/++pNyJNyxHtjS1wbdRU1IyEgyBbFOviLvtN3CchcV5WJhYNXjcg9uNY/+FTRy5sgNXex8crFwM22rqKqtwIfk4549dzVr15a57UzunAx4NHsh/lAhkBUF4oPyRv3wIgiAIwm9VcRycqjiLUWG3+fnkNR6N8K9WT5/JvvZs9Eby6tnvAQa1HUd6TgopGQmsOrCAh1oMw7dRk+rt1xFKKxV39+deuXGKW1mJjOw8FWOlKcfidpFTmFFnGzKZjBZ+nTibdBCAMJ8OyGXyGuvWRVHpHmUyOTpJH9dJkkSvFo/h5RTYoHYqH2NUee9xQ8dppFCi0TXsuCAAF1tPhnV6FgCtTsNXW9/E3sql3jIAjVZN3M0zHNlxPrOGpk2B6nulHjAikBUEQRAEQRAeGGM7zkddpuXHo8+jUOiDlZ2rzvLpa5uZPKsPD49pzZalpygr0TB0Qtt6WqvuzbHLmTyrD67etS8/rbrP1pzEbEdS8lYjk43gkVa+6CQdZ68doJlPO7ydg7mQfNyw7HXDlo008Qmvcww6nZb8ohxc7b1xtfcmT5XFnbybhkD2YvIJ3B38KCot5PrtK7T071JnewAl6mLMjC0xVppSqi7m8o3TNCpfBuvfKIRziYc4+XMuPgFutOntw88LTlJSpOap1zrx/S8foNVqGNtrOgBL5+2jpEjNhNd7NeSRVrF/80WCWzUCwLzUjR+WLeHUN6YMfKINT73WiYLiPBysXWhk7ccXn8dw41crUJYSPD6NVj276p+PVuKrN3eQdqUMrVrLiCmdSLs1hXzfh5GQEawbwuTnvwEJCvNSeG/p43gFhrDx64sUBOei0WowUtQfRqlK8rEw1Z8dv2TVOBwcm2Bn6VSlbP/mKZQ4NsfD0d9QBpCQGoutpSM3r90uqaHpJsC5e99cNNv6BUA5cWb+3EWzrd2BpUBLIGHizPyISvUUwMdAL0AJbAZenTgzX6qn7HlgfKUu/YBvJ87Mf3nRbOv+wOCJM/OfrvfB/EFEICsIgiAIgiA8UOydLTm9P5HW3QMA+OXnWAJCXQ3lA55s9ZvbfmfxqHrr3Hsc3K7EENq4JxJ7NYb8HCskJHxdmqCQGxHm255cVSZL9swFQJNrSiNl3cfg6CSJ7aeXUaouQYYMKzNbOocMNJRbmduxYv/nqEoKaBPUs8ZlxfcK8WrNtbQLLN49B0szGzwc/dBo9bOTTb1aU1iSx2XNKZJlZ0k9aoKEfu+rsdIUX+fGaHRqzE0s6+qiXlfO3EKj1mHnpG+nTXBPlKZyrN66QIFuPyv2n6F94z44WLtwdYMlVi2zaDstF61Gx7k1FkhtzcEaCnKL8Qp25I1PB5KXpeL5h2PoPMAEDzsPVCo5qz44wfvLnsTe2RJVfglKY33INGxiR+Yt3k9KRgJ+5R8KnIjfw+lr+ykuK2T76eUYyY14qsermJlYci7pMFduntZn9Jcb09H9bnZ+Q5mxKy5yE/q0eLTKvV5IPk4z7zbVnsHH617yRpJ45ZFPL1R+f9Fsa3PgeaCik0LgLcAaePueZiLRB8Ph6Fe3bwJGACvqKps4M/9z4PPy/iqSTi0DmDgzf+ui2dbvLppt7T9xZv61+r+bv58IZAVBEARBEIQHSq/Hwti15hytuweQfiOH0hINPkF3Z8MqzxheOnWDr97cgaST0Gi0jJzSiW6Dm7Ft2WnWxxxDaWyETpL43xeP4BngyNiO83n7uxH4BDuTej2b+VFbycsuQqGQM2ZadyK6+ZOaW0zTFWe4E+qK1a08FKUaLrZw55hnAElzBlQbb7fQwVC+33P6oh+RtdHPJF9aZkmCcT4rry8hLSWHjn0a06iXB/+b8RMZqTKGRHZjyHh9MDS243y6Dgohx62QJd9coN/gzowco8/iG38ula/f3kFJcSMuf72dZ97uw4jOU8jNVBH1xFJyMlUAhHcMYNKbvfXP5HX9M1mv+br8mTzEoYXFBIa58vCY1iw9vY87qXm8OW4Zpp3OIcU1pmtQCRbWptXub/XXhzm07QpajQ6HRlZ08i3E3lkfrHZo0tdQb/vy07Rr05tuoc0B8PB1wsN3OEvnuehnf0fdneFNis3h5aeeJKi5PkiftXolB7Zc5pGJ7bj6vQ+D5rYEwMbBAr+mLiQneEKr22Qf9OXRSWGG/jf+EEGfEauwN21KcsJ3ZJ8uZL3dPPxl1+jUbx6tg3rQOqgHi2Zb06bnu9xI2MHFI/OI6PYGHZr0NYx/84/9DUfzVdxXhyZ92fxjf0J9p+qTP11YxYXjX6HTqlEAju53l4Ivmm19HYhRunacINMU13QA/KPA/okz84sBJs7MzwP2L5pt3a2Gus2B3RNn5qvL294FPIE+kK2rrLKHgfSJM/MrHzOzCv2M7es19PmHE4GsIAiCIAiC8EAJa+/DliWnKMgrZvfqWHo+EkpCbFqNddd8dYQhkW3o+UgYkiShyi8FIOb9X/hqxySc3GxQl2rQ6qrvE/3whfX0ezycPiPCSUnI4LXhP/LN7mdws9UnLtIqFST1DsYsoxCPw9cpKp8V/nT6Ztr1CqLdQ0H13ktyQgbv//QkWp3EuE7zURWU8sHKp8i+U8CkHl/RZ0QLzCyMAcjNVGHXwpLHPhnMm8M30ayNFx7+jrw3eQ0vfjiQ8E5+nD2UxHuT1/Dt3uf4df0FnN1tiP7pSQAK8orrfCb3upkTR9iTZQR7tOPsFSOWzz9YbTnxnnXnSUvO4ZN145DLZWxZcopv39vFa58NrdZe7NFkHp3Uvt5nAhAQ6sq+TRcJDHPl9s1cLp+6iYuHbY1laQUJ+A50x93Wg7OnS3GxzWHa8B8oUamxtG1K7+H6721g6CjatblEXuk1WvQaxsFtLzJ43B5Dn5KkY+BTWxs0vpp4+PXEP2QYMpmM3KwEti59+N4qrmr7xnOBL2u4vBtwrIFdnQLGLZptvaD89RDAtgFllY0HvrvnvSPAh/ybAlmZTNYX+AxQAN9KkjTnnvKXgQmABsgAxkuSlPxH9C0IgiAIgiAI90Mmg84Dm7B/4yX2b77E3J/H1BrIhrX3ZtWCw9y5lUd4Jz8alycMbN7eh3nTNtHuoWBa9wjA1cuuynVFhaUkXr7NQ8P0e1u9Ap3wa+rClTO3mNYnmIVfHybfW39NsYMFymI1L3XXJ3t68YOBNFT73sEoTYxQAh5+DrTuHoBcLsOxkTWWNqZkpuXjGaDPWNx7RAtCIvTBUeseAcQeTQaZDCOlgvBOfgC06OiLkVLBzcQsGoe7sy7mKDHRu2nW1ptWXfzqfCb3CvYK45n++ntxHnGDr9/aUa3O0d3xXI1N4/kB3wKg1eowtzKpVg8gM70AWyeLBj2Xia/3YuG7u5jSbxFO7jaEdfBBYSSvUja6+wJuS1Css4WVF/B/zQ+tNp7rV+4QveQJ1Gotk3uf5+DWFAaPCyEz/Qw3ri7lZqIZzoqF5GVdrdJnUNjjDRpbbfJzkji5bjyqgjTkCiVFhbexs5FVjtd+fGXovKO1XO6Bfj9rQyxGv7/1EJAPnEAfCNdXBsCi2dauQA9g7D3t/qXZlH93ICuTyRToPxV4CLgJnJDJZBslSbpUqdoZIEKSpCKZTDYZfaQ+4vf2LQiCIAiCIAj1qcgQnJpbTHBeCXsu36HfY815acj3hLb1wtqu5jNcAYZEtqVtr0DOHEzi67d3EN7ZlzGvdmfmN48Rfy6Vc4evM2PUEqbM7m/YcwvUfq6OTMaQcHcWAo3szUlVleFmr+9/QDPXWi6qnbFJpazFchnKKq/laLW6mi5DkvTZepEkakqKLJNBk1YefLF1ImcOJLFn7XlWf3WIuWvG1vpM6lRLP0gwcmoneg9vUe+9mpgYoS7V1FsP9EuGp306xPD6zbHLDQG9jYMFgWNa852VKcVqLZ77rmFmk8unuxNoZmlCp35N9B8OmBjh6X+LxEs5aLVl7F7zFJ4BCzC1UNJ31Fss+6zqOfRK44YF2bXZs2487R6Kxid4IJKk4/s5LhgbUTl9cmEdlxejz2Zcr4kz83XAzPL/WDTb+jXgcn1llYwBtk6cmX9vRuW/NJvy/ee/rq4NcFWSpERJksrQr58eXLmCJEm/SpJUVP7yKOLcI0EQBEEQBOEvUJEh+FZuMRKg0Ul8ujuBY1lFjHm1G6Omdq7z+puJWbh629P/iVYMHtea+HOpaDU60lNyCG7hzvBnO9Kysx+Jl9KrXGduZYJfExd2r9Enl71xNZPEy3do3OJuYqXdL3clac4ADs3o8Yffd00qxpKXpeLU3muEtvPGw98RdZmWc4evA3Du8HU0Gi3uvg6k38jB3NKEroNCmPhGL66eT0enk2p8JjU5secqeVn6/bW71sQS1t6nWp22vQLZXL7MG0BdqiHx0u0a2/Np7MzNa1kNutf8nCK0Gn0Qf/ZwEtfj7tBtcDND2UfbrlCs1mJ+uwDT3GJc/K9RqtFxxdaM0wcSkSQJjVpLWooLXoE2aDUlSDoNd1Il/Jq4cOnkogaN436UleZhZesNQNyZH9Fqa16yXYvzQHC9tYBFs61NF822tin/2gt4FvikvrJKxlJ9WTHUkk35z/JHLC12B25Uen0TqCtXeSSw7Q/oVxAEQRAEQRDqdG+GYIBSjZaPdsQ1KIDcuPgEsUeuY6RUoDQ2YvKsPui0Oj55dROF+SXIZTIc3awZN716W699NoT5UVtZ/91xFAo5r34yGBuH+mft7meP7P1wcrNh2rAfyL5TyPBnO+Db2BmA1796rDzZkxpTMyWvL3gMpbGC2CPJrPv2GAqFHJ0kMeW9fsjlshqfSU2ad/Rh3mubSU/JwcPPgYk1HLfT85Ew8rOLmT5iCQCSTmLA6Fb4NXWpVrdDn8ac2p9oCIgvnkhhztR1FBWWggT7Nl3kxQ8G0qqrP3FnU/lm1g7kcjnW9ma89e0ITM30yZbizqZituw0/jLQmhiR0sUPhZGWx43eQ+ulIPVcR0a1OoSNnQ+2jnl0HeSDsYk1LbtE8f6Uo7i4L0Zp3PW+n/++jZMxMro7adpn5Joq5e0fmsPOVY9jYeWKq3cnTMzsqXsStoq1wALKMxSXH6OTDJgANotmW99Ef1TO24ANsHfRbOuK6frpE2fmny7/uq4yFs227ghYAdXXiUMf4OeGDvj3kklS7YcgN6gBmWwY0EeSpAnlr0cDbSRJmlpD3SeBKUBXSZKqfcQgk8kmAZMAvLy8WiUni220giAIgiAIwm/nO2NLjat8ZVBjhuD/qsrZlP+tigpKeXXYD8xbPw4TU2X9F9Sh45w93MqtvgrW3das1g84Tu27xp7155k2b0iN5X8GmUx2SpKkiPprwqLZ1juAGRNn5p/5k4dVU98OwB6g9cSZ+WV/RZ9/xNLim4BnpdceQLX1BTKZrBf6DFaDagpiASRJWihJUoQkSRFOTk41VREEQRAEQRCEBqvIENzQ94V/LnMrEya83ovbN3J/d1vT+gRjplRUec9MqWBan9pX5xYVljJ+Rs/f3fefaApw/xut/xh+wOS/KoiFP2ZG1giIB3qiPxT3BPC4JEkXK9UJB9YAfSVJSmhIuxEREdLJkyfrrygIgiAIgiAItajYI1t5ebGZUsH7j4QypJZsu8KDoXISMDdbM6b1Cf7H/Zm4nxnZB83v3iMrSZJGJpNNQb9OWgF8J0nSRZlM9g5wUpKkjcBHgCWwWqZPV5YiSdKg39u3IAiCIAiCINSlIjD5pwcswl9vSLi7+HPwL/a7Z2T/LGJGVhAEQRAEQRCEB5mYka3dH5G1WBAEQRCEf5DusyZQplFTplFzNf0GTT38AAjzCmRir0f5csdKYp55m1xVAYv3buDFAU/+7j47vjGG3W8sxMzYpMHXFJWW0C/6WbZGfYmFiRmfb13G4n0buXb7Bite/JB+LToa6h6/eoH/LfuMotISjJVKPhs7nRY+wXWWlWnUdJ81oUp/1zNSuTZ/C/aW1vR//zkWTHgdHye3amMTBEEQ/tnEjKwgCIIg/EclZ6TR9e3xXP+y5lPv6iu/XxMjWqMuKyPmzGkUCn0Sld3LVzD/pZeY9N57DIgcX6X+vC1L0OkkXnn4KQBOJV7C1sKaqd+9z9R+jxsCWUmSaPziYL6bPIuOjcPZeXgPnzz7HNvOXAKoUnYk/hxTv5vDifeXUb6dySBq5stcXLIG3wD9kSb5JSp0ncNYPOcbAAY3cmXFtauYWdR/PEpNGnq9TqcjasgQXv36axzd3Ni7Zg1rv1zAjfh4JrzzTpXndPPqVb6ePoP87GwAxr/9Fi26dq237I1hwykof1+r0ZASF8dne37Bp2lTPpz0NA9PnECT1q1/030KgvDXETOytRMzsoJQi+Nrj7Lxw/UgSahL1Xi38OHZxc8D8JT5SBbeWYyppWk9rfwx1s5eTamqhFHvj/7D2ozuM4t+LwwkvH+reutl3cjCzMqMspIyOo7qzOAZj9x3fweW7OXsttNMXfbybx3yffcX0C4I10D9TMvpzSeJO3yFUdG/f+bpXvt/3MvO8kAg62YmxmYmWDlYATBu/gRWvrGsQc+6Pjmp2cx/Yh4zf5mFXC5n+f+WcGL9cTKTM4g+8REeIXcTyJ/ddpqf31mFVqPFws6SSQsn4+TjXG9ZhXXvrWHde2sM7eZn5DPvsQ+Z+cssFEZVszwK/y4HLp9m5oov2DfrO15ZMpe8okI6vjEGM2MTdr+xkPnblrHm2G60Wi0mSmPmjZlGmLc+8LMe04E3H3uaTaf2kVOYz7sjnmNw6+6GsmGShJ2LM5t+Xsn3149xJy8b2y0ncfHzrnEs3/+6gc0z5htet/JrWmO9rIJc/TgbhwPQu0MPxrV15+z1ODwdXKqUtQ9qTlpOBmevxxHu27hKO0fiYwlrFc6nazcAcGzHTt6cMomCt1RYmf224PW3OLRxE17BwTi66f998g1pxqtff8XP87+oVvfzF1+i35in6D5sGKmJicx89DG+OnQQE3PzOsveXb3K0MbRbdv4ac4H+DTVP99hLzzPotdnEr1+3V9zw4IgCH8CEcgKQg1y03L44cUY3jn8Pg4ejkiSRErsg3uu8ZNzxxDevxW5aTnMaPkKzXqE4t8m8O8eVp0OLN2H5f/Zu+/4mq//geOvm5sdiRCRQUKsRMRIYsbeW6lNdVilpVurVUoXrdJNa++9996xCUIIEmSHLNnj3vv5/XG5RCbVku/v/Xw88nj4nHM+55zPJ8N9f8742FkbAlmfbvXx6fbvPNBs8XorWrzeCoA5I2fh5l2F9qM7Pfd2Nk/bQPvRnTAy0r85zad7Azq825nv2k3OVS4tMZU5I2cz8cAUnKo747/yKIvem8+4LZ8XmvfQ7YBbhJy+gZ1LOUOajb0NVRtWx3/FUcO1ipJvxpBPaDl5KP7fLDakDWzambGdBwFw8MoZPlg8nQOT5hryrc2tODx5ASevX+KNP780BLIPterbl99nTOXd33/Fz6Ea08+9TfkqlQ35OdnZLJs6jYCjR3CMCGV95neM+uEHLKys+PW99zExN0N94Cgr1h7nml8zPvj9N8rZlMHOujTbzx+hq08LVu/aQJ0dVwkfEYO3mweNtl7l288+JPHCVWJjozF3gPD4mFyB7PlbV7mfnoJj+UdBdVZ6GmalrDh5I5D2dRrnuo6Fk6dw+cQJNDk52JQty9ifZ1LeRf+w6Myevaz86Se0Gg0qIyM++O1XQ5AI+hHXBZMnk3T3Hu//+gsmZrmnW+9Ztoz+H31oOK5UU9/Ph7/bj7t95Qo+rfX32LlKFUrZ2nLuwAH8unUrNO9x+1auot3AAYZjt1q1uB8fR1RoKM5VquRpUwghSgIJZIXIR1JsEmpjY0qV1Y+qqVQqKtWtnKvMnlk7ObflDKkJqQz4fjANejYCYPZbvxN9PRpNdg4OVRwZ/tfbWJUpxaw3fqP+Kw1p+Gpjts/cwpYfNzI7cj5GaiPG+3zM+6s/BgXmjJxNdkYWOq2O5q+1pMsH3QFIjErkp57TuHf7LuXdHBiz/APMLM24cjCQdVPWkJOZg06rpcenvWjc1w/Qj6a6+Vbl5qkbJEUn0rB3Y/p/MyjP9Z5ce5ydv27j/VUfU7aiXYH3xdapDI7VnYiPiDcEskeXHWb/nD3oNDosSlvy5q/DcKrhjCZbw9KPFnL1aBBlnMviVCP3GrTtM7dwZuMptBotZZzLMvTPkdg62rLh27VEX48iIzmDmJvRVPZ2o9vHr7Dy82XEh93D95WGhlHV7ztOwbVOZcIu3SYhMoFGrzam79cDObLkELfOh7Lsk8Wsn7KGAVNfIzEyPteI8LYZm/FfeRSAKj5VGTLzLcxLmbPh27XE3Igm/X56nnv9T1w7dpVtM7bk+T4kRSey9OOFxIfHk52ZTeO+fvT4tFee87Mzszm98RSDfnzdkObu55GnHEBsSCyly5c2BPF1O3rz97A/SYlL5t7tewXmWZezIScrh8UfLuCdRWOZ2unrXPU26evHivFLJZB9iT35Kok3G5d56joCbgczY+tiEtOSMVIZcTM2PFd+n8btAGhQrRbRSXFkZmdh/ti6WJsabpgkptG+hg9b5syldd++3Lx40ZC/8c8/sbKxZvBfP/PhoumUNXNk3W+/MeRz/cOUsGvX0L7iR/9OA9j18VdcPHKEei1bsvy9aUxa/SfTNi2gbpmKGBupMVE/+hhzOiyYxEaOeKk9qLl4Y648gKVHttGomheBO47xQdt2ZKSlkRwfT+k+rYlKuJvnPvQeO4a3Jn8FwJ7ly1n87XeM+/svIkNC+OPjj5m6eRPOVaqQk5VFTk6O4byczEx+fe99HFxc+Hj2rDzTmzU5OVw7e5bq3t7F+n5UrVuHIxs30n3ECG5evEhkSAj3IiKKzHso6d49Lh49wtiZM3Klu/vW5+LRoxLICiFKLAlkhciHa51KVKlflQ/dx1CzeU2q+3nQdGBzw3RRAAtrC6Yc+57rJ4L587VfDIHsa9PfwLqcDQDrJq9m28wt9P9mEJ6tvLhy8DINX23MlUOXqVCzIqHnQijnUo7MlAycqjuz7JNF1O1Yj56f9wb0I2sP3TofyuSj32FZ2pLpPb7n+KpjtB7alsr13Ji4fwpGaiPuxyYxqekX1G5XB6sypQCID49jwt6vyEzJ5BOv92n5Rmscqz16V/b2mVsI3H+Jz7Z/iWVpy0LvS/SNKFITUvForh95CPa/yun1J5mwdzImZiZc3B3AvFF/MfHA1xyYv497d+7y/dnpaHO0fNd+CvaV9CN8/iuPEhsSw6TD32BkZMT+OXtY+flSRi8cC+hHBKcc+x7zUuZM9BvPmkkr+WTTeHQaLR95vkfroW0N1xB1LYLPtn9JTmYOX7eeSLXGNWjxeiuOLT+cazrv0aWHDNdxcXcA/iuPMunA15hbWzBnxCw2T1tP/28HF3qv/4mCvg9/j5jFK+NfxaNZTTTZGqZ1+YYqvlXxalsn1/m3zoXgUMUBU3PTIttyrO5EUmwSoWdDqFK/KsdXH3vQh/hC86zL2bDhmzU0HdAsz1RjgMo+Vbhz6Q5ZaZmYWf030+pF8T35rszIpAx+3H2XbI2u2HVka3J4/Y8J7PxiFvUquxOdeA/3D17JVcbMRP8zqDZSP2g3nN8PhgEQm5zJqdB40irZcXTTZo5t2cy0LVtyBbKnd+8hPTUF7YYNlI6L5nS5W1T2rGXIb9SpM5fuX0ZtYkLVOrWJvn2bei1bUq+yO1s++w2AiFuhvP3zImo4Vzact+yPpdjY2ZGRlcmA2atxs3v0dy4zO4v1p/bxXe1uRKaoGD9/HgCB/seZ+OYQjDt0zXMvzh04wI6Fi8hMS0Or1RjSLxw+gm/btoYA0MTMLNeI6+SBg2jesye93hmd7z1OTkjA2MQEMwuLgr4Nubz/66/Mn/QV+1etxqVGDTwbNkRtbFJk3kMHVq/Bp3VrSpcrlyu9THl74qOji9UHIYR4GUkgK0Q+jIyM+GDNJ0RcCefa0SDObTvLzp+38t2Z6ZQqqw8QH456VmtYncToRLIzszE1N+XYiqOcWHUMTY6GrLQsQ8BVq7UX22ZsRpOtITEygS4fdOPKgUDKuZbDs7UXAO7NarLy82VosjV4tqxFzZaPPtzVblcHK1v9Gq4q9atx91YsAMlxycwb9TcxIdGo1WrSElOJvhFNtQcjpg1fbYyRkRGWpS1xdnfmbmisoU8bv1uPnYsdn2wcj7FpwX8Oln2ymDUTVxIVHMmQn97Exl4fqAfsOE9Y4B2mtPgSAAWFtMQ0AK4evkKzwS0xNjHG2MQYv4HNuHH8mv687ee4dT6USU30IzBarWBgktYAACAASURBVBZLm0dBdO12dQxBtYuXK661K2FiZgJmJjhVd8p1Dc0Gt0RtrEZdSk3jPn4EHb5S5FrUKwcv07iPHxYP2mw1tC3LP3k0tbKge/1P5Pd9KONUhmtHgki5l2wol5maQVRwZJ5ANiEyAZvypYvVlmVpS95d8j7LP1tCTmYOdTrUxdLWCrWJutC8G6euE3oulH75jNoDqI3VWNpYkhSThENVx2e/GeJfMX13sCGIfSgzR5sn7XHWFlZkZGei0WowVhuTmZONRqelYln9g4y5+zcU2e5XW4LI0uqDWq1OYcXZZDSu5Vn4/Xf4NG+BTdmyZGmyDeUVRWHUtGlUb9iAamO7sumPHYbgGMD0saDQyEiNTqPvf2xSPA62doZ+GauNqepQ0VDWxFz/cOWXHcsBqGT36Gd0y7nDVClfEecy5Yl8rO+1m/qhycmhXHbuKb13w8OZ/9VXzNi5C4dKrlw9c4aZo995eAGF3o/aTZty/uBBOr/xBuZWeR8Ompqbk52VVWgdj3OsVIkJixcZjt9t3oKKNaoXmffQ/tWreHPipDz1ZmdlYV3m6UfshRDiZSGBrBCPeXJa3riO7vQc1ZF2ozoy3udjrh4JokHPhgCYPBgZM1LrPwDpNDqC/a9yYO5eJh74Ght7G46vPsahBfsBsK9cHkWncGL1Mao1rI5nay/mDJ+FnWs5PFvqA9kGPRtRrWF1Lu+/xLYZmzmy5BCjFox50N6jp+xGaiNyMvUfDBe/Px/vrr68t+ojVCoV4+p8YMgD9AHgY+dpNY8+1FZrWI3LBwKJC7uXa5T2SQ/XyF4/EcyP3b7DvVlNXLxcURSFFq+3ovekfnlPKuSznqIo9PisFy3faJ1v/pPXWtg1PFnvk9P4il3useOC7vU/kd816HQKqGDyse8wNin8z7GpuSk5WTmFlnmcV5vaeLWpDcD92CR2/rKN8m7lC83bM3s30cFRfFxTPzKeEJnA9B7fM/zvUdRuVxeAnKxsw8++eLlEJWXkm67TFfzLWLaUDf2adKDxhCHYWlmzb+IcJvQaTqspw6hY1oH2dZoU2W5mjhaV0aMNwLK1YOU6hIwGS9lmco8tX75Og4R0Hj6Wa9ixA5v/+ptPfX1pXtOH/ef9qV2mAi41ahAUGcrKm6e46WTG6LnfUvlcBGM99VPoFxzcxNqTe9HqtNQpU4FS5rlHNJtNfBONmjwbPAEsP7qdIS26wd3cv8snjx9BlaOlsW/u9bHpqakYm5hiW94enU7HrsVLDHnerVux5pdfDOtLH04ttiylf8g54JOP2bFgIVMGDWTismVYWlvnqrtU6dLY2pcjNiwcB1cXipJ0L47S5exQqVTsX7UaEzMz6jZvXmQewNUzZ0hLTsGnbZs89UZcv0GXt94qsn0hhHhZ5d1VQIj/px5Oy4tMysAkNZ3kq2F8viGQTQGRJETEkxKXjH1l+0LrSE9Kx8LGklJ2pcjJyuHIkkO58j1b1mLjd+uo1aY2dhXLkZqQyuV9gXg+GHmNDYmhtKMtzYe0oucXfQg5e7PIfqcnpVPOtTwqlYrL+y9xN6T4o4e129flzV+HMaPXD0QEhRdZvkYTd9q+3YEN36wFwLuLL/4rjpAQEQ+ATqvj1vlQ/bW2qoX/iqNoNVqyM7I5udrfUI9PV1/2z9lrmDqdk5XzzJtpPWwjKy2T0xtPUrOFftqzhbUlGcn5f7D3alObk+uOk5GSgaIoHF50gFptvIpsK+TMTaZ1+eaZ+pkfC2sL3Jt6sO2nzYa0+Ig4kmKS8pSt6OVCzPWoYtf9sA6dTsfar1bReng7w3TggvK6f/IKv4XOZua1P5h57Q/KVijLuC1fGILY+7FJGBmrKeMsozgvI2fbvFNV1ca2eHlMyJXWvKYPh6csMBz/PvRzzk5byb6JcwD4oOtrXJ6xgV0TZvNx99dJXnzcUDZ58XFKmT8aZbRzmoDKSP9go6zTBED/QCghw5qty7dz7K/NHP92CVXKVzCc03vsWCrX8uSTTp0pteYYc0a8S8SNGwB4VqjCxN4jiZt/mNt/7qRXwzaYm+hHaD/vNYzzP6zi4vS1/PTax3keRh37ZhEXp69l0Tt5f0c3f/orw9ro155fOnqUD9q24/02bfl5zFiajB2eZ9pt5Zo1adq9G2NbtmJi7z44uLo+us9VqvDujJ+Y/vbbvN+mLZ9268bd8Nx/P3uPHYNf9+5M6tuPlMTEPP1p3LkzAYcOGo6PbNzIUG8f/LduZfmPPzLU24ew4GAATu/ZzWi/poz2a8qxzZv5fMECw7UXlgewf9UqWvfta3gV0kOZaemEXQ+mTrOmCCFESSUjskI88Pi0PJVOR+WTFzHbe5yVy7Zyxt6K3pP6U7meW6F11OlYD/9VR/ms3keUrWCHm08VQh8LRj1be3FkySFD4Fq9iTtBhy4bNlg6tf4EJ1b7ozYxRqXSr7ctSr9vBrL4gwVsm7EZVy9XXLxcizzncZ6tvBgxZzS/9J3OmGUfUtm78Gvs8WkvxtX+gDsXb+PRrCZ9Jg/g577T0el0aLI1NOzVGDefKrQe1o7wy2F87vsJZSuUxb15TeJu6zdUaTqoBSnxKXzfUb+ZkE6no+2IDrjWyf8VHYWpXK8yP3T9lsSoRBr2amSYVtxqaBtWfbGcHb9sY8D3g3OdU7ejN+GXw/i69UQA3Hyq8MpnRb9SKD487rmPRo5aMJYVny3hiwbjADAvZc7wv0Zh62ibq5xDFUcsS1sRfT3KsHHW0o8XcXbzae7HJvFD128pZWfN1HM/AbB+ymqunwxGm63Bq20d+n0z0FBXYXmFCdx3ifrdGxRr1Fv898Z1dM+1RhbAwkTNuI7u/1qbzrYWRD42Eny17w8AVHgiqH7/t18N/zY2MWHI558bNndafGgLdZq0yVMuv+OHHFxdWBYUZDjeHJN7reeTxw+1HdCftgP6G47/2ruWkW1753veiG+/ZcS33xqOB306zvDvhh060LBDhzz1P35+9+HD6T58eL796DFiJD+NHk3HIUNQqVS06NWLFr3ybvIG0GHwYDoMHvzUeQBjZszIN/3Q+nW06dcPM8vC90UQQoiXmUopYq3Hi1K/fn3l7NmzL7ob4v8Rt/Hb850NqwJuTcu7EYh48Yr7LtznZenHi2jYu3GBuwX/206s8Sfk9A1e++nNF9L+dx2m8Nbvw3F2r1B0YfFC5Ls8wvvf+349ucEU6IPnqa/W/lfb/V/gv2UrHg0bYOf4368337N8OS169sp3Da8Q4uWiUqnOKYry77w/sISTEVkhHnhyZOHxdCEAhsx484W236RfU1LjU9DpdPm+b/LflHwvmdbD2koQ+5Lr6V3hPw0gH7b1XwbP/yua9uj+wtoubBRXCCFKChmRFeIBGVkQQgghhBAvExmRLZiMyArxgIwsCCGEEEIIUTJIICvEY/7raXlCCCGEEEKIpyev3xFCCCGEEEIIUaJIICuEEEIIIYQQokSRQFYIIYQQQgghRIkigawQQgghhBBCiBJFAlkhhBBCCCGEECWKBLJCCCGEEEIIIUoUCWSFEEIIIYQQQpQoEsgKIYQQQgghhChRJJAVQgghhBBCCFGiSCArhBBCCCGEEKJEkUBWCCGEEEIIIUSJIoGsEEIIIYQQQogSRQJZIYQQQgghhBAligSyQgghhBBCCCFKFAlkhRBCCCGEEEKUKBLICiGEEEIIIYQoUSSQFUIIIYQQQghRokggK4QQQgghhBCiRJFAVgghhBBCCCFEiSKBrBBCCCGEEEKIEkUCWSGEEEIIIYQQJYoEskIIIYQQQgghShTjF90BIYQQQjw9jUbL8sXnOLT/JsbGRuh0Cg0bV2LYqEYYG6ufqU7/o7ews7PEw9PhmfsVciOOiPAkWrapVmiZJQvOMGVqZwCmfr2PiwGRJMSns3nXcCwsTQxld++4xoY1F9HpFBydbRj3RRtsbMwLzbsSGMPvPx8x1JGUmEHZspbMmt+XpKQMJo3fwc9/9EJtLM/zhRCipJK/4EIIIUQJ9NPUg9y5lcCf8/owd8kA/l7Uj4qutuRk6565zuNHbxF89e4/6lfIzTgOHwwptMz8OSfpP9jbcNypqwezF/TNUy7sdiKL5p3mh196MHfJADxqOrBwzqki82rVduSvBf0MX+41y9O6XXUAbG0tqOnpwL491//RdQohhHixZERWCCGEKGEiw5PwP3qLFetfx9LSFABjYzVde3gCoNXqmP/XSc6cDgOgQUNXho1qjFptxPTvD2BqqiYiPIl7d9Pw9HJg3BdtOHcmnJP+twk4F8HO7Vfp3a8uvg1cmPr1XtLSssnJ1tKwSSVGjG4CQE6OloVzTnHmdBhqIyMcnW346NNWLJ5/hvT0bEYNXUPtus68+36zXH2/G5tCRFgSnl6OhjRv34r5XuftWwlUrWaHra0FAA0bu/LJe5t5/5OWheY9LjExnfNnIvjgsfRW7arz9x/H6djF45m/B0IIIV4sCWSFEEKIEubmjTgqVCyNtbVZvvk7tgYRcjOOWfP0o5wTxm1nx9Yguvf0AvQB4g8zu6MyUvHOsLWcPxtB/YauNG5amRru9rzSuzYA2Vkavp7aBQtLEzQaLZ9/vI0zp8Jo0MiVVcvOEx2VzKx5fTExUXM/KQOb0ua8MawBJ4/fYdI3HfPt26ULUbjXLN7U5SrV7LgefI/oqGQcnaw5uO8GGRk5JCdnFpr3cOoxwL5d1/FpUJEyZS0NaTVq2BNyM46MjBwsLEzya1oIIcRLTgJZIYQQooTYFBDJ9N3BJN+Mo3xsKpsCIunpXSFPuYCzEbTv7IGJiX6tbIcuHhw/EmoIZP2auWFqpv8IUK2GPdFRyfm2p9UpzJ19nKDLsSiKQkJCOiE34mjQyJVTJ+4w8h0/QxulH4yMFuXevTTKlCle2Youtox+rynfT94LKvBr7gaAWm1UaN7j9uy8xtCRjXKlqY2NsLIyJSE+nQoVSxerL0IIIV4uEsgKIYQQJcCmgEg+3xBIRo4WEytTVGnZfLH6AkCeYFZRQPVkBapHKaamjzaDMjJSodXkv652/ZqLpKRk89tfr2JqZszP0w+Rna01tPEszEzVhjqKo3Xb6rRuq1/fei0olq32VlhZmRaZB3D1SgzJyZk0bFwpT7052VrMzJ5tUywhhBAvnmz2JIQQQpQA03cHk5GjDwBzLExILWtB6eA4pm+/CujXxW5ce4mM9Bx8GlRkz65gNBotGo2WvbuC8amf/zrUx1lamZKWlm04TkvJpqydJaZmxsTdS+XEsduGvMZ+ldi49hI5D/p0PylDX4dl7jqe5FbVjojwpGJfd0J8OqCf5rxk4Rn69K9brDyAXTuu0a6je57diRMT0jFSq7ArZ1XsfgghhHi5yIisEEIIUQJEPQgUH4qpZodd+H2sj9xixBurUHT6DY9MTI3o0t2TqIhkRg9bC0D9Bq507lazyDbadajBT1MPcORQCL371aVnn9p8O2kPo4etxd7eCm/fRyO//Qf7sGDOSUYPXYuxiRHOFUoz6ZuOePtWYN2qC4x6aw216+Xd7KlWbSdiopNJS83CqpR+je+UCbsIvqbfLXnoayup7FaWqTO6AfDTtAPcjUlFo9HSsk01evapY6irsLysLA1HDobw66xX81zn2dPhNG1eBZUqz7i1EEKIEkKlPOvcoH9Z/fr1lbNnz77obgghhBAvhabTDhD5RDALUMHWAv/xbV5Aj57dymXnMTVV07tf3aIL/ws+HruJ9z9piWulMi+kfSGEKC6VSnVOUZT6L7ofLyOZWiyEEEKUAOM6umNhkntNp4WJmnEd3V9Qj55d7351MTN7MZPCkpIy6NrDU4JYIYQo4WREVgghhCghHu5aHJWUgbOtBeM6uue7a7EQQoj/DTIiWzBZIyuEEEKUED29K0jgKoQQQiBTi4UQQgghhBBClDASyAohhBBCCCGEKFEkkBVCiCJM8/+ST/eNNhzvCd2G40wjrsVdMaS9trE7KwLnE5MaxatrHu0g6zjTiLTsVADqz3PjatzlYrd75M4+mi/yNBwnZ92nws8mLLjwpyFt1tmfGLPz9We6LoCw+7fxnGX/zOc/T73WtGZP6LY86WH3b7P00pxcaU97LwsSEHOGfus60HB+VVours2ra9pwIuLIc22jKP7hh+iwvEGR5S7fvcDm4DXP1Mb045OpNduBtku9DV+p2SnPVNel2PNsvb7umc59Wtuur2fiwQ8AyMjJYMD6TnjOsqf2X055yv588ltaLq5Ns4U1eX/3ULK1+nfZbgpeneu6PWfZM2Jb/yLrvHLvIkM29fiXr1AIIcSzkkBWCCGK4FexFSciDhuOT4QfxsexEccjDgGg1Wk5HXWMpi6tcSzlzIZ+B55Luw2cm3Lnfij30mIBOBV5jLoO9Tke/qgvx8MP4+fS6rm097IKT77N0sC5z73eq/cCeW1jN0bX/5jTw0I4/EYgM9rPIT793nNv63m4fO8CW66vfebz+3oOYf+QAMNXKVPrZ6on8O55tt1Y/0znanXaYpdVFIUfT3zFmAafAWBsZMy7Dcax4tWdecruC93B9hsb2DnoFEffDEIFzAv4DYCe7v1zXXd5Kyde9RhYZJ217OuiKAonI44+w5UKIYT4t0kgK4QQRWjg3JSw+7cMAeWJiCN80HiCIaAMvBuAtakNlWyrFGuEMyDmDC0X186V1mZJPc5EHc+VZmFigbdjQ/wfBMwnIg4zzHsMQfcuAo8F0BVbGertutKP1kvq0nWlHwExZ4BHo65Tj02g3VIfmi704FTksTz9ytJkMWJbf7469BGKojD77Aw6Lm9Iu6U+dF3px+W7F/K9nqNh++m60o92S31otbgOm66tMuT1WtOaKYfH0WNVcxrOr8q3R8cb8oLjg+i8ojHtl/ny7o4hZGky863/8wNjuBEfRNul3gzb2teQviV4DV1X+lF/nhvzA/4wpN9MCGbghi50XN6QNkvqsfLywnzr/ePMjwzyGkrryh0NaW5lqtGtRu8i2yjoXoN+xL7D8ga0WVKPdkt9CLp3CYADt3bRbqkPrZfUpc/adtxKvJmnTxqdhgHrO9FheQNaLPYyjCwmZMQz/fhXHA3bR9ul3kw48B4A56NP8eqaNnRYVp8Oy+qzN3R7vtdakOiUSHqtaU37Zb40X1SL7499YcjL0mTx1aGPaLW4Dm2W1GP41n7cS7/LzJPfcOj2btou9WbSoQ8B2Bu63XBt/dZ14E5SKKCfVdBhWX3G73+XLiuasOHaCur9XdEwWgowaEPXfEea/cMP4WjljEMp/UipidqE5q5tKW1mm6dsUNxFGldsjqWJJSqVitaVO7Hh6oo85c5HnyYu4y7t3LoWWSdAL48BLL88v7i3UwghxH9JUZSX8svX11cRQoiXRY9VzZWN11YpKVnJSvNFtRSNVqM0nl9dURRF+fPMdGXMzjcURVGUO0m3lJp/ljOc5zBDpaRmpSiKoii+cysrQfcCFUVRlM7LGyv+YYcURVGUE+FHlLZLvPNtd9qxL5Vxe0cpiqIonZY3UmJSopRBG7oqV+9dVgKizyg+cyopiqIoWZosxWeOq3L49l5FURTlyJ19is8cVyVLk6XcSbqlOMxQKbtDtiqKoijrgpYp3VY2zdXfhPR4pefqVsqcc78Y2r6Xdtfw78O39yqdlzfOt4+JGQmKRqtRFEVR7qbGKPX+rqgkZiQoiqIoPVe3UkZs7a9odVrlfmaSUvPPckpIwnVFURSl/VJfZdXlRYqiKMrZyBOK00y1oY+POxZ2UGm/rH6uNN+5lZWvDn1suAa330opqVkpSo42R2m/1Fe5Hn9VURRFSclKVvwWuBuOH9dsoaey48bGfK+psDYKu9c3E4IVr9mOhmvMzMlUUrKSlbtpsUrNWfbKtbgriqIoyvJL85ROyxvluT6dTqfEp8cZ/v3ujteVRRdmK4qiKCsvL1SGbulj6F9SRqLSdom3EpMSpSiKosSkRCn1/q6oJGUk5rmWH/2/UjxnlVfaLKmntFlST/ls3zuKoihKena6kpqdqiiK/mfolVUtDNc17diXyrAtfZVsTbaiKIoSl35PURRFWXZprjJy2wBD3bGp0UrNP8sZ7vHii38Zfr4O396rOM1UK+eiThnKD93SR1kXtExRFEW5lXhTqfd3RUMbj/vBf5Iy9diEPOmhCTcUr9mOudIO3tqtNFtYU4lPj1OyNdnK0C19FPc/yuY5d9zetw3f06LqVBRFuZ0YotT7u2KedCGE+K8AZ5WXIDZ7Gb/k9TtCCFGAx9/ZaW5XmRXKdqxNbWjk3BS1kRo32+pci7vC8fDDdK3+6lPVPdx7LIsuzsbPpSULL87irXrv5FuuqUtrPj8whtTsFNJyUnEo5USTii04HnGITE2GYVpxSEIwJkamtKjUDoDmrm0xMTIlJCEYK1NrrExK0aFKNwB8nRoz+fAnhjYytZn0WN2ccX6T6VHj0Yjnpdhz/HZ6KomZCRipjAhNvJ5vH+Mz7vHh7mGEJt3A2MiYpMwEQhKC8XVuDED3Gn0wUhlhY1aa6nY1uZ0Ugr2lA9fiL9PXc4i+T86NqVmudr71A6Ao7Dg+nfPBmzAyUlM3NRObu6FExwfjaueOrVkZolIj0Ck6biRcZdT2gYZTs7RZ3Ii/SvWyHk9WWnB7D/R0HwCAa+nKhjY02hxMjExxMrJg+vIOjBu8h7I6I35Y2pYK9QbQ1q0zVcpUB8DM2AwzzDgefoha9nVxt9OveR7g9RbjD7ybZ52qTtEx++xPHLi9C61Oy/2sRCxNLAA4d3gaFtospi1pQ3ZOOsYWtiQn3WbQxi6G81WouJV0k3qOeV852NdzCJNb/vREe1omH/6Ys9EnAYhNi+bIhfnk3LvO3tDtTGwyhdnr+xNxNxD7Mm6MG7zn0bk6LRsPT+bczW200lhyOXAl1VpMZpDXMCbsf4/V+8cTeGsf3VQO3Lm+HW/HBqhUKnpX7s7mfV9w8+wCYlIi6GRTDRQdAFdC9xEYspsB7acTnRJBrfL1ivweAbSq3IHBtYfTb117zI0taObamlORuacEZ+RksCl4NVsH+BerTgB7K0diUqPQKTqMVDKJTQghXibyV1kIIfKxKSCSzzcEEpmUgQKkJntwLPwwS85tp0nFlgA0qdicY+EHDOtjn0b3Gn05F32SwLsB+IcfpJfHoHzL1Xf2I+z+LbbdWE9DZz99uxVacDz8MMfDD9P0QSCroKBSqfJW8CDNTG1mSDJSqdHqNIZjUyNTfJ0asSdkq2ENY7Y2m+Hb+vJ1q585/EYgK1/dSZY2K98+frbvHfxcWnLo9UvsHxKAU6mKZGofTRM2MzbP1bZG0betIp/+FsApOYGouKt8NHAHX7xxhItWZtRwa0ts/A19vUZqNDoNiqJQ1tyOfa+dN6yJPDv8Fl2q98pTZ53yvgTEnC603Vx9f9hGIfda//A8LwWlWNe74doKTkf5s7n/EQ69cYk3644mU/Povmc61WT86weYNOwkFV39aKgxZ367+YZrPT8yLN8gtiB/np1OWk4auwad5uDrF2lfuTMJEedoXvctFBSMjc3p4jeO17v8mefcE5dXEJtwgyYtviCxgicx8dc5H7wZgMqYcjcxhHZtvyXC3iVXXjuPvoSULkPbtt+yV3WfipZOHL+0FIBaVdoRFnuRe0m3MTe2KHC6eX5G+X7EviHn2TbQnxplPaletmau/O031lOtjIfhYUJxZGkyMVObSRArhBAvIfnLLIQQ+Zi+O5iMnEcb0xjl1ERnFMuBO5sNo6CNK7ZgQcAf2JjZ4lq68lPVb6I2YaDXW7yx6RV6ewzC0sQy33LmxuZ4Ozbit1NT8XuwFrauY30uxp7ldNQxQ1q1sh5ka7M4FnYQgGNhB8nR5VC1TI0i+2KkMuLnDvMpZWrNyO0DyNHmkKXJRKvT4GztAsCii7MKPD85KwkXm8qoVCoO39nLraS8az+fZG1mg3s5L8M6xvPRp7kaF5hvWV1mCqUy0xnUYSaW5qX1iSoVVSu3pF4N/SizS2YO+45O5cixH/FJ17Dy0hzuxAQwc2VXpiz0Y/ryTtyJCQDgRrg/05d34J0Gn7AscB7rzv7G9OUdADh0ZRVfzPVh1d5x1E3NZM3WkcTEPxqJPhWwgLVbRlAjJYU9F/Vrb4+FHUSj02CiMkYbeYnkoB18vbApMfHXydJkkZqdQmZMEKXCLzJ5QWOW736fFRfn4GXvjVpR8D8+E7e4aP5Y24fAgCU4paZSytSa5Kz7bLi20tC2SmVE+oMdsAF61B9LhLGONUemABAcdpRvFrfkh6XtmLq4FeeubQLgTkwA0RdX57qn05a0ITTqDMlZSThYOWFmbEZkSjiBN3dibuOMqYkFHap0Y2HgXCo51cfMxArNg4cfpUxtSM66T+S9K7i7NqdRxeZcvHuOcvaenL22nlWXF1LVwhnPSq0wMjIGlQr3Si05e02/QZSpiQVDvccyclt/mlRojhpyPRjwrtGdU5dXUtO+NiGJwUX+LIF+mdTDNeyJGQn8eXY6o+t/nKvMyisLGej1VrHqe+hGwlU87es+1TlCCCH+GxLICiFEPqKSMnIdqzBFlVMDjVaHYylnAOo5NCA6NdIQTD6twV7DiU6N5I26owst19SlFaFJNwwjwcZGxrjZVssVQJuqTZnXfR1T/SfQekldpvpPYF73tZiqTYvVF5VKxbS2f+JiU4k3t/TCRG3KOL8pdFrRkJ6rW2JpYlXguROaT2XKkXF0XenHtuvr8LSvU6w2f++0mPkX/qD9Ml+WB87F16lxvuUstBoUUws6r26ea7OnJ0XHXmJQx5l8/sZhtodsZuqqruxLvcGlUha0ajiGBVuHo3lsk6Fa9nVZ+soWNlxdwdW4y7RaXIe/z/9CWmosTeu+zsVS5lSt1JLdp34BoEyOltvhJxg/5ADv9d3I+TsHCI4PYqr/BMb5TSEmNNXOrAAAIABJREFU4TqdG45lQI+5BGXf49NVHei2yo9jQWsIurmT/l3/wt8km103N7P/zB/82Xkpu07OwMTUilvlnHir21xITyBbl02LxV6M2NaPRhWaGfprbmxBhiadNkvqMeHAe9ial+HNxl9wKzaANkvq8fa+EVyzLsW41/bwbp+1bDoyhfTMJCo5emOkNiEnRR/ohUScRKUyoopzA0b4fIB/xCHaLfXhiwNj8bBwxszaEYD3G03AsZQTbZbW46M9I4hMDgOgZaX2JGclsSpkA9vO/0VpU2tmtP2LXRfmcu7OQTZfX0Mfn3cJDN2DRpOJSqcj8OYuEpMjDNfS1qUdtVMzsL59BjPTUvjVGWLIc3OuT3DYUTpU6c7x8MPoHkw7Bmi/zJdX1rQgPuMe3nNcGLf3bUA/4t1nXTtaLPai2yo/BtcebphKD/oNzwJiThumij+uoDoBDt7e/dTLBoQQQvxHXvQi3YK+ZLMnIcSL5Dd1v1Lps215vvym7n9ubay9slQZtKHrc6vvf9W5a5uUaUvaGI6j4q4p05a0Ub6e30RZd0C/GdB2/x+VVXvHGcpE3g1SpsxrlKueKfMaKZF3g5TrYceUH5e1N6Q/fnw97Jjy/aIWhrxrd44oPy3vrCiKoqw/OEnZdfJnQ97FGzuKdd6GQ5OUXSdmGvJuRpxUfliqP++Hpe2UkIhHGyGtPzhR2Xjoq3zvw1dzfZXIe0G50i5c36Z8u7CZoiiKEptwU5m76U3l+0UtlGlL2igf/VpZCY08qyiKopwJWq8s2DpCURRFWbhtpOJ/aVm+bfy5rr9y4fr2POlP3jNFURStTqtsPTZVmbakjfLLqleUDYcmGa6rsDxF0W9w1WZJPSUzO1WZu+lN5ezVR5tuxSbcVL78u56iKIrywa6hyu6bW/Lt678tMydTab24rmHjMiGEeBGQzZ4K/JIRWSGEyMe4ju5YmKhzpVmYqBnX0f251D9gfSd+OjGFSS1+fC71/S/aFBBJ02kHeH1JPGF3b7L29DUAnOzc+WzIflp6DyMjK9lQ3uyx6dkFr2MFIyPjXGtZczS51/4aGz++ntgInfJwPXHhm0MVdJ6iYFirbOjGg0NFUfLkPY07MRdwKqffxGrNvs+o5uLH+NcP8dmQ/diWckLzYK2yd43u3I4+R/jdQG6E+1PfI++aYQATY3M0BayFfpKRyohuTcfz2ZD9vN9/E9aW9jiWrV5k3nu73uK9XW/yXevfMDOxwtv9FcO0Y9B/P0wfrE3+otn3pOekPdvN+YfCk2/zZfNp2JqXeSHtCyGEKJwEskIIkY+e3hWY+mptKthaoAIq2Fow9dXa9PSu8FzqX9V7FyeH3XiqjWf+P3l8s61UrQPRWfVYd+AT1p25ZiiTlZNe4PkOZauh0WZzPUz/vtzrYcfQ6nIoX6YqdjauxN+/Q3pmEoqicD54Y7H6VMO1GQHBW8jKSUOn03LyyqqiTwI8KrXg/LVNZGanoigKJwKX4+7aAoDqLk05fUX/DtX0zCQCQ3YVq06ASzd34X9pMa19RunPz0qmrI0LKpWKa3cOE5d0y1BWrTahsddA5m56A1+P3pgWsCbbuVxNYhOKXuMMkKPJNDxISEiO4NjFRbT2fbvIvEmNJ3Nq6HUaV2yORptNYMgunMs92pgpNuE6zvb63wt7Kwd6euSdDvxfqFbWnTZunV5I20IIIYomr98RQogC9PSu8NwCV/F0ntxsKyB5KDWstrLnyACuB9lgaWaLTSkH2jcYm+/5xmpThnafx/qDX5J9KB1TE0uGdp+HsdoUW2snWvuOYvryDtjZuOLqWI/o+KI3FfKq0oHbUef4cWk7bKwcqO7SlPup0UWe5+nWlsh7Qfy8sisALg516djoQwA6Nf6IFbs/4PvFLShr44Kbc0PMzWwKrGvB1hEYq03JzknH0a4Gb/dajpuzLwA9mk9g7f7x7DvzO87lPA3B4ENNvAaz68QMmtV9o8D661Tvwtr94+niNw7Qv2Lnq3n10WizyMxKYeIcb5p4DaKL3zgyslL4fe2rhpHvHs2/xMVBvz66sLxbUWfYd+YPVCojFEVL1YpNDPcD4OrtQ9Sr3g0hhBCiMKrHp1e9TOrXr6+cPXv2RXdDCCHEC+A2fnu+E3lVwK1pXf/r7vxrtNocdIoWE2NzMrJS+HV1D3q1nIJ7pRbPva0zQes4F7yRUb2WF1pu1voBdG8+AZfyhbzX91+SlpHA72v78MngXRgXc6MyIYT4X6ZSqc4pilL896r9PyIjskIIIV46zrYWRD6xc/TD9P8l6VlJzN4wGEXRkqPJwtej178SxM5aP4C4pNuM6Lm4yLJ92nzPvcRQeAGBbNz9O/Rr94MEsUIIIYokgawQQoiXzriO7ny+ITDX9OLnudnW4fc2ocvRotPoSIu4j3Vl/YY+pauWw+eTlv+4/uzkTC794U/y7URQgcpIRe1RTShX15l7FyJRdFDepwLWlvZ8+tqef9xeQW6uu4TKSMU7vVeRfjeVgGmHOH/zBNauZWjx6yuGcjqtjst/nyTuQhQ6rQ6nJpVQ3PQbZuWX5zmsISqVirvnIzk9eQ9WFfTTodVmxrT4RV9vyKbL6HK0VO9b/PewVnL0fr43QAghxP8sCWSFEEK8dB6uTZ6+O5iopAycbS0Y19H9ua1ZbvlbTwDSY1I4PHYjrWf3fi71PhS08AwWDtbU/6ItAFn3M9Fl6Xcx1geECuV9nu5aFEUBnYJKXbx9GjWZOdzaFkSbOX0AMLYwweN1X7JTsrix+mKusnd2XCM9OplWs18FBU5O3EX0sVs4N69SaB6AjVvZXEHxQ5W71OTAyLW4dfPE2MLkqa5VCCGEKIoEskIIIV5KL3KzresrA4g4GAJAGQ97ar/TFIB9b66i1exXMS+j3/X34u/HsHSwpnq/3KOOmXFp2FR+9NoWs9L618ncD4nnzq5gUODu2XAqtqlG9b51ubM7mJANgahUKqycbaj7XjPMbC24s/Ma0cdvY2JlSkp4El6jmhA463iuwPvAiLV4f9ySMh7lc/Uh8nAo9nWdUZvq/6s3tTbDrrYTd89H5rne+6Hx2HtXwOhBkGzvXYHwAzdxbl6l0LzCqE3V2Nd1JvJIKJWe00i6EEII8ZAEsv+ARpvDwkO/sTdwM2ojY4yNjKloV5mRbT/BrXyNp6pr9Lw+DG42imYe7QiLC+XL1aMBGNT0bTrVe7XA8+bun8GbLcdiYqxfT/T1+g+pWaEOfRu/9ewXVoj76YmMWdAfgIzsNO6lxOJqp/8w4+feFhc7N/yD9zF14Jx/3NZnK4bzRosxeFasx6kbh5m99wdCYq/Rt/FbvNd5oqFcfMpdpm0eT1RiGBqdhjdbjqVzPf2HvCnr3udmzFVD2ZuxV/lh0Hxa1OzAgoO/sDdwC2ojNWojY0a3/4zG1VsBMGHVaPr7DaOOq6ytF+L/m5iTd4g8HErzX3pgbGHC+R8Ocn1lAJ5vNaBim2rc2RmM+yBvctKziTp6i7bz+uapo0pPL858t5/w/Tcp6+mAU5NKlKvrTOmqdlTq5I5Oq1BrWENAH9xeW3KOlr/3xLysJUELTnP5rxP4jm8DQPzlGFrP7o2lozUARsZGxF+Jwa6WI/cuRKE2N84TxALEX4rGzsuxWNdsW70cEQdDqNSlJigKMSfuoM3WFJkHkBKWyKF3NmBkosathycubasb8sp4OhB3IUoCWSGEEM+dBLL/wDcbPiIzJ4P5b2/F2qI0iqJw4Mp2bt278dSB7OMOBe2ktmt9xnX/rsiy8w/+zOBmowyB7POg0WowVuf/o1HasgxLx+jXc50LPc7vu75l0Ts7DPnbzq95Ln24HH6ezOwMPCvWA8C5rCuf9/yRg1d2kK3JylX2151TqFmhDtNfW0BiWjxvzuqMT+UmONg681WfXw3lbkQH8e6CfjSurl//5lmxHoOavo25qQU3ooMYPb8P2z47h7mJBW+2HMvM7ROZPXz9c7keIUTJcS8gkgqtq2Jiqf+7WqmzB1fmn4a3GlClRy38P91Gjf51Cd97A4eGLpjamOepo7xvRTosG0jchSgSrsRy+ut91BhQj2p96+QpG3cxCseGLpiX1Y/yVu5SkyPvbzbk23k5GoJYALcetbi9NQi7Wo7c2hqEW/da+V5HRlwaZmWKtzlWpY7upMekcPTDzZhYmVLGw574K7FF5pVxt6fDskGYWJmSFpXM8fHbMbezwr6eMwDmZSzIiEsrVh+EEEKIpyGB7DMKiwvlcNAutnx6BmuL0gCoVCraej169116Vhoztk3kaqR+LVKneq/yeot3Abh19zrfbPgIjVaDW/nqhuBs14UNrDo+D0XRcenOGaYOnMPhq7vZF7gFrU6DqbEZn/aYSg2nWkzfOgGAEXNewUhlxKxhawEIjQ3m3fn9iE2OoraLL5N6/4JKpSItM4Vfdk4hJOYqWZosfKv48X7nr1AbqRk9rw91XOtzJSIAU2MzZr6+5JnvTVpmKhNWjSb0bjClzG2YNnAOdtb60YKlR2dx8PJ2NDot9jaOfNHzR0Pe4zafWU6HOj0Nxy52bgAcubo7T9kbMVcZ4DcCgDJWdlR3qsW+y1sZ3OztXOW2nFtJx7q9MDU2AzCMvgJUc6yJoigkpydiXtqC6k6eJKTFExYXimu5wqfPCSFKjk0BkbnX3TZwweyJMoqif83P4x6+D9XS0RqbKnbEnArj1rYgfD5pVWBbJpamOPlVxsmvMjZV7QhZfynfQFZRFFA90eJjh0+uL63YqirXFp8l6WYcCVdi8P0s/z6oTdVos7X55j1JpTbCc2hDPIfqR4mvrwzA2tW2yDwTq0cPUa2cbXBsUomEoFhDIKvN1qI2VRerD0IIIcTTKN6OESKP69FXcLFzw8bCtsAyCw79gqLoWD52H3NHbmLnhfUcv34AgMnr3qd3wzdY8u4u+jZ+M1ew26vBa3Su14elY/ZQ0a4yXbz7sHD0dpa8u5uRbcfxw+bxAIYR27kjN7N0zB5DQB0SG8zM15ewcuwBrkUFcjrkKAC/7JyCT+XGLBi9naXv7iExNZ6t51YZ+htyN5hf3lj+j4JYgKuRF3mv00RWvncAN/vqrDm5EICdF9YTEX+beW9vZcm7u/Cr0YZfd36dbx3nb52klkvxdq/0cK7N3sAtKIpCVEIYgWFniUmKyFUmR5PNnkub6O47IN86dgSso0LZSpQv7WxIq+3iy9lQ/2L1QQjx8tsUEMnnGwKJTMpAASKTMvhxdzBZGl2ucuV9KhBxKARNRg6KonBndzD23o/+NlR5pRaX/jyOsbkJZdzt823r7rkIctKzAX2gmhwSj6WDflTV2NIUTVq2oax9vQrEnAoj68Hrhm7vvIZ9IWuDjUzUuLSvwamv9uDSrrphDeyTbNzKkhqRVPSNAbRZGnIe9Ck9JoXbO65RtVftIvMy49N5+D76rPuZ3D0fSemqdoZ6U8KSsKlihxBCCPG8yYjsU3r4ND/+/nlsTVLZFBBJT+8K3Lp7nUlrxpCZk0GTGq35qOvXnAk5xoddpug37zC3pn3tVzgTcoy6rg0IjQ02rOP0cvGlqoNHgW1ei7zE4sN/kJyRhEqlIjz+VqF9bOnZETMT/VQ3dycvIhPuAHDs2l6CIi6wwl+/fjUzJ4PypR+tn+pYp2eBU4qfRp1K9XGw1X/o83LxMQTSx67t5WrkJd6Y1QkArU6Llbl1vnXcTY6mbKlyxWrvvc6T+GXHZIb82QGH0hWoX6UpxurcIxiHr+7GoXQFajjlnYJ3/tYJ5uyfzm9vrsyVblfKnrv3o4vVByHEy2/67uBcr/MByMzR5klzbFyJ5FsJhum9ZTzsqT7g0YM1e+8KGBkb4dbds8C27ofEc/nvk/qRVZ1CKRdbar/jB4BzMzdOf7OXg6PXGzZ78njdF//Ptufa7KkwlTq5c33VBSp3rVlgGadmblz+6wTug3wA/ejovrdWo8vRoknPZvfgFVTu6oH7IB+yU7M4/ul2VEYqUKnwGtnIEJAWlhd5JJQ7O66iUhuh6BQqdXTHsZGroQ/3zkVQa2TjQq9FCCGEeBYSyD6Fh0/zM3K0qHFBp43h8/WngEb09K7B0jF7WHtyIVcjLwH6p/CqJ6aLqR7MF3syvSA5mmy+WPU2s4evx8O5NveSY+j+Y+EbED2cOgtgZKRGq9MY+vPj4PlUKFsp3/MsTK2K1aeiFNb+W63eK3BU9HFmJuZ51sIWpIyVHVP6/m44/nDJECrbV8tVZtv5VXT37Z/n3MCwc0xe+x4/vraASvZVc+VlabIobVkmzzlCiJIp6sGI5+MSzIz5wsuRgU+k1xjoTY2B+c8KSYtKRqfRUaFVwcsOqverm2cn44esnG3yvO6nUkf3fDdEqtTZg0qd8z7ojLsYjWNDV6ycbArsQ5ka9hiZqLkfGk/pKnaoTdV0XD4o37IWdla0nd/vqfOq9vKiai+vfPOSbyegUqsKHLUWQggh/gmZWvwUHn+ar8WBLKUuZrpF/LgrwFAmIzvd8O+G1Zqz5exKFEUhLSuVfYFbaFC1GVbm1lQp787uSxsBuBIRQEjstXzbzNZkodVpcXgw5XX9qdzTfi3NSpGalVys/jf3aM+SI3+i1emvISktgaiEsALLj1nQnysRAQXmP63mHu1Zf2oJyRn6qW7ZmixuRAflW7aqgwd37oUUq9776YlotPpg+WyIPyEx1+hYp5ch/+79KC7cPp1rzS1AUMQFvlw9mu8H/o2Hc+089d6+d4PqjgWPuAghShZn2/w3PiooPT9BC89wbNw2vEY2KnBK77/N/7Pt+l2UhzcssmydMU3JjE8vsty/ITMujTpjCh9ZFkIIIZ6VjMg+hSef5t/XvUkpo+1kp05i4G8zsTYvjb2NA0MebOg0tNUH/LTtSwb/3g7Qr39tUqM1AF/1+YVvNnzESv+5eDjXppaLT75tWplbM6Ltx7w1uyuOpSsYzn9oUNORjFnQHzNjc8NmTwX5oOsU/tj9HUP+6IBKBSZqMz7oMhnnsq55ymp1Wm7EBFHexql4N6cYOnv3ISk9kdHz+gD6EdpXG71Odae8wWIrz86cunkY3yr6qXgXbp9m4pp3SMtKBUVhb+BmJvT6icbVW3ElIoCZ2yehVqkpbVmWn4Yswtz00QfT7QHraObRPs/o6vStE8jKyTSsOQb4qs+vVHOsSUZ2OrfuXqd+labP7fqFEC/WuI7uhlk1D1mYqBn3FK+G8XyrAZ5vNfg3uldsTX/oWuyy1i62WLsUvJfDv6l8fZcX0q4QQoj/H1QPN2l42dSvX185e/bsi+5GLk2nHSAyn6lpFWwt8H/wvr//FdeiAll/ajETev30QtpPy0xh5NxezB+1FXOT4o+WPC8bTy/jbnI0b7cb95+3LYT49+TZtbijOz0L2VhJCCGEeJFUKtU5RVEKX1f4/5QEsk/h8TWyD1mYqJn6am35IPQvOHXzCOVtHP/RO3mf1eazK+hQpycWppb/edtCCCGEEEKABLKFkanFT+FhsCpP8/8bjaq1eGFtv1I//w1RhBBCCCGEEC+eBLJPqad3BQlchRBCCCGEEOIFkl2LhRBCCCGEEEKUKBLICiGEEEIIIYQoUSSQFUIIIYQQQghRokggK4QQQvyP6r7h/9i774Cqyv+B4+9zB5c9RRQUmYITUdwj99670oZle37LvjZs2DK1sm/TsqGWmpqZe+eeKG5FEUUFQUH2uNxxfn+gVxEEzIH2+7z+iXM+z3mezzlY+bnPc577CXHpyXdsvKn71hA183U2nz1qO5dnMtJ29juMXPrVbRt3/rEd/HZ48y3p60JeFqNWfItVtQIwZfcy+i6YSNTM10s8y81nj/Lg0i8ZtngKT6z8nsTsixWKGS0mPt6xkAELJzNs8RQ+3LYAgEKLmZFLvyKnsOCW3IsQQvybyWZPQgghhADAbLWg02iLnbNYrWg1Ff/cO8zTlyXxe2hTIxyANQkHCHD1vqV5Xmtw7ebXjd1o/tMOrGNoWEs0StE17WvWZXh4K0avnFqsXZYxn3e2zuOn7k9Ry9WbZfExTNi5kC87jSozBvC/3cux0+hY0O8VFEUhLT8bADutjh5BjfjtyCaejOhyo49BCCH+X5FCVgghhPiXS83LYuKuxSTnZmC0mOgWEMGoBh2AolnbfiFR7EqOx8/Zk55BkXwWvYRGVQM4nHaWwbVb8GXMChYNGINBqwfg5b9n0C2gId0DG5UYK8oniM2JsWQZ83E1OLAkfg+9gxuz5MQeoKhYfmnddDKNeRgtJupVqckbzfuj1+owWcxM3LmI3SnxeNg7U9uzOmn5OUy870Gm7ltDvrmQl5r0BCh2fPXPi0/sZtWpfbgbnDiZeZ5xLQfhZe983fu/mtFiYk3CAf4T1ct2rlHVgFKf6ZnsVLzsnal1qUhv7RfG21vmklGQS2LOxevG7LQ6lsbHsGzQWBRFAcDLwcXWb7eACEYu+0oKWSGEKIcUskIIIcS/3Ntb5vF4w4409gnEZDHz9JofqetVgxa+oQCk5mcztetoAKKT44nLSGZs83681qwvAFsSY1l9aj+9g5twLiedI2lnmdiu9O/bVhSFLrUasOrUPlr61qbAbCLYvZotrlU0fNB2GO4GJ1RV5Z2t8/jrxG4G127OH8d3kpyXwdy+L2NRrTy56geqOrrd8P3uPZ/A7N4vUMPFC4BnVv9Y5v1fdjj1LDVdvGwFe1lquXqTlp/NodQz1KtSk+Un9wKQnJtRZkyjaHAzOPLD/rVEJ8fjoLfjmUZdbQWzl4MLeo2WU5nnCXCresP3LoQQ/19IISuEEEL8iyyMSWTSyliSMvLxCitg7ZEUdqfEk7Er19Ym12TkVOZ5WyHXK6hxsT5qulShoXct2/Hw8FZ8Fr2E3sFNmH9sB32Do9Brr/9XiN7BTRi3eQ5pBdn0CoosFrOqKr8e2sTWpGNYVCvZhfnYXyocdyfH0zMwEp1Giw4t3QIiiDl/6oafQaOqtWxFbL6psNz7vywlLxNPe+cKjeFsZ89H7R7gs+ilFFrMtPKrjYudPTqNtsyYyWohMeciYZ6+vNikJwcvnOblv2fwZ/9XcbazB4qK2ZS8LClkhRCiDFLICiGEEP8SC2MSeX3BAfJNFgAsVpUv1h7HORBm9Hy2xPuvlzno7IodO15zHFG1FlZVZe/5UyyJ38P0Hs+UmUcNF0/0Gh1/Ht/FnD4vEpeeYoutOLWXvRcS+KHbkzjpDfx04G9OZ6UCoKLaltteS6tobBswQdHGSNfjoDPYfrZe6rOs+7/MXqsvs99rNa8eQvPqIQCk5Wcz89Am/Jw9y4wZLSa0ioZuAREA1Pf2x93eidPZqdT1qgGA0WLGUMYHBUIIIWTXYiGEEOJfY9LKWFsRe5nRbEXNd+eXg+tt55JzM0i9tMFQRQ0Lb8mbm+bQsIo/1Zzcy23/XONuvNC4B+4Gp2LnswsLcDc44qQ3kFNYwIqT+2yxKJ8glsXHYLZaMFpMrE7Yb4vVcPHkaFoSVtVKrsnIpqt2Ri6Lk95AZNWACt1/iEc1ErIuVKhfwNaHVbXydcwqBtVuhoPersyYu70TUdWC2HHuOAAJWRe4WJBDzUszyBarlcTsi4RctRxbCCFESfJxnxBCCPEvkZSRX/yEoqKqGtISQogPP8+wxVOAouLu7ZaDqHLVJkPl6RoQwSc7FzE4rEWF2jf0rlVsefJlvYMas/HMYYYu+hxvR1cifQIwmk0ADKrdnGPpyQxdPIVqjm6Ee/pRcCnWyb8+axIOMHTRFGq6eFHHy7fCub/fZhifRS8p9/5ruHjhYufAqcwLBLgVbdQ0aeci/j5ziLT8HJ5d8yNuBkfm9n0ZgG/3rmLf+QRMVgstfEN5rnF3W19lxV5vPoDx2+bz+e5l6DRaxrceioudAwD7LiRQv0pN2zJjIYQQpVNUVa3sHEoVFRWlRkdHV3YaQgghxD2j9YR1JF4qZhVdIR4hu7kY2ww/N2e2jO14U33vPX+Kj7Yv5Pc+L153+e+tkGsy4qQ3UGgx85+/Z9C5VgP6hza9beNda8XJvRxMPcOrTfvcsTGv9uamOfQNibItSxZC/P+mKMpuVVWjKjuPu5HMyAohhBD/EmO6hfH6ggOoLmew9zxHbkogDjo7xnQLu6l+x2/9gx3njvNe66G3tYgFeGb1NExWC0aLmWbVg+kd3Lj8i26h7oGNyDTmYVWttu+SvVMKLWYifQKliBVCiAq4JTOyiqJ0B74AtMA0VVUnXBM3ADOAJkAaMExV1VNl9SkzskIIIcSNu3rXYl93B8Z0C6N/pF9lpyWEEOIfkBnZ67vpGVlFUbTA10AX4CywS1GURaqqHr6q2WNAuqqqIYqiDAc+AYbd7NhCCCGEKK5/pJ8UrkIIIf71bsWamWZAnKqq8aqqFgJzgH7XtOkHTL/083ygk3K71yYJIYQQQgghhPhXuhWFrB9w5qrjs5fOldpGVVUzkAl43YKxhRBCCCGEEEL8P3MrCtnSZlavffG2Im1QFOUJRVGiFUWJvnCh4t/jJoQQQgghhBDi/49bsWvxWaDmVcc1gKTrtDmrKIoOcAMuXtuRqqrfA99D0WZPtyC3f5Wxo8egt9Oj0+sBCG8QzrDH7q+0fL766H/0Hd4P/6BaHNi9n79m/cnZhLN06duVQQ8NsbXLuJjOzG9mcDE1DYvZQq+hfWjerkW5MYAdG7ezbP7Sok9CFIVX3h+Di6sLv/80h+CwYKJa37mvZBBCCCGEEELcHW5FIbsLCFUUJRBIBIYDD1zTZhHwMLANGAysU+/WL7C9yz312jP41arxj661WCxotdpbkkfckeNYLVb8g4q+7L5qdR8eevZRdm3eUaLtnGmzCQ4P4fnBL5KVkckHr4wnrH4Y7p4eZcbij51g2fylvDJ+DK7uruTl5KE3FBXx3Qf0YPK4iTRpFVXuV0HsPHiCJRv3oAIms4WA6lV14Ls1AAAgAElEQVR4akhnAMZ9M49xowdgp9fxyme/8vKDPanh43lLntGtlpNXwJTflmM0mWnZMJSebRrZYrn5RjZEH6Zn20jbuY9/+oserRvRKKzWPx7zyMlEfl+5nXefGnRTuV/PrcjxsvFTF2CyWLBYrCSnZeBXtej3WKt6FVo3qn3L7mPW8i2E+lejab1gEs6lMnPJJk4np9Ew1J/nhne1tSswmpixZBOnz6Vitlq5r3E4PS79zsqKldXn2p0HyS8opHe7O/t1JEIIIYQQd5ubLmRVVTUrivIcsJKir9/5SVXVQ4qijAeiVVVdBPwIzFQUJY6imdjhNzuuuGLb31v5e9lazGYLigJDHx1OWINwAMY89gr3dWvP0f1H8PH1YeQzD/PHjHns2bYbJxdnQuvW5vjhY7wx8S0Als5bws5NRcVoYGgg9z/xIAaDocSYG1dtoFm75rZjH18fAHZvi8ZqsRRre/bUGXoO7gWAq7sbfrVqEL0lms59upQZW/3XKroN6I6ruysAjs6Otj7dPNzw8PIg9uBRwhvUue6zycjOZeaSTbz79GC83JxRVZXTyWm2+PvPDLnutXebQyfO4mhv4K3RA0rE8gqMLNuyr1ghW5pxC1/m6fb/wde9ZpntbtZv26fRPKgtIVVv7rsrr/bsbyP5dOgP2OvtS42//eRAAC6kZ/He1AXFfrdHTiaWes1X6yYSUTOKtqEdbedUVeWdv/7DyJZPEuoTXqz9xcwcDp9I5P7urQBwdXLg/u6tOJ2cxqETZ4u1XbJxDzqthvefHUKhycwHPywktFZ1Qmr6lBm73Of2uG0cObcT6IrJYmLqhs85nXaS3AIjnQq+w8HezjbWyoOL2HVqK1bVSoBXMPc3H4Veqy8zlpZzgXcXvUp19ysfjL3QaSzOBhcOJu5l/9k9PNB8VHm/FiGEEEKISnErZmRRVXUZsOyac29f9XMBcO9UDHex7yZ+Y1taPOjhIdSPrE+DJg1p2aHoL9ZJZxL54r3P+WTaZNs12ZlZvPrBawDs2b6bw3sP8faU99Dr9HzzyVe2dvt27mXX5p28/skbGOztmfb5Dyybt4QBI0rOYsUejKX30D4VyrlWcAA7N+6gZqA/F5IvEH8snmo1qpcbO3cmCR9fHya+MQFjQQFNWjW1Fb0AwWHBHNl/pMxCNjMnH61Wg7NDUTGuKAq1qlexxR95+zu+e/Mx7C/N9F6WkZ3Lr0u3kJaZjclkoXmDEPrcVzQL9spnv9I6IoxDJ86SkZNLj9aN6Ny8PgBJF9L5bdkWMnPyQIXurSNoExlWZn9Xs1qtzF21gwNxpwFoEOLP0K7NiT11jt9XbSffWMi4b+YxomcbwgKq266buWQzeQVGxn0zD4NeZyt2j55KYummGDKyc2laL7hC91cRGdl5fDdvDfnGQkxmCxG1/RnWrSUAf67bRWZqLRYdjyM5bTcBvt70ahvJnBVbSc3IoUndQIZfagtFBfryLXtJz8qlWb1gBncp+oBk4d/RbD8Qh16nLVpa7lbh9EplsVr5ZdEG4s6koKDw9NDOtAy+j3VHlqPk+LFu5yEsVisahwysbkqJIhZgU0wsUfWCbKsAPFyd8HB1Iik1vUTb08lptIkMQ1EUDHZ6wgKqs23/cUJq+pQZu9znjzs24q20BUCjaOhcpydOBhcmr3ifHQfjaB9VF4Aj5w4QnbCdMd3fxU5rYNaOn/j76Aq61utTZgzAwc6RN3p+WCL3+n6NWLL/Dy5kp+Dt4nNzD14IIYQQ4ja4JYWsuHNKW1qcci6FHz6dSkZ6BhqNhvSL6WRnZePi6gJgK3IBYg8cJapNM9ssa8v2rVi5cAUAR/Yfpnm75tg7OADQrks7/pgxr9RCNiMt3TZTWp5hj93P7z/OZvzL7+BVtQrhDcJtS5zLilmsVhJPJ/Lye69gNpn5/N1P8fL2ovl9Re/Qurq7cfL4yTLHrunjRaBfVV757DfCA3wJ9a9G60a1cXYsfVbvsh/+WEff9k0IC/DFbLYw8ZfFBPp5Uz+kaCaz0GRm3BMDuJCexVtfz6VNozD0Oi1fzFrBoE7NaFa/qGjMySuoUH+XrY8+wunkVN57ajAAn85cxvroI3RsVo8BHaPYF3u62FLTy0b2blNiFhKKZhBfH9WPgsJCXpsyG9dQa6n5fDh9Foeyl6JoTVisZjqEd6dlcDsAsuyj+WT5PswWE94uPoxoMRpHewOGGgfpUacb9Xwb8emMpSzauZL4rN3U0nThSO4SHm7/II1r9eCV6W/x7ZotVKthh6NnGpsSYrgvNZzqVTywkM+etAW4e+uoFVCVzQl7MG46Rf+o/qzYso///fdh7PQ68o2FvDp/Uam/q5+3fMP5rGRbft3rFC34SMk6x8xt31NoNpJvLCSl0JHHm77AI33vY9GG3SzasJvHB7Rn1vaf2HxhD68/NhS9TsuUFZ+SfM4bALPFzKJ984g7fxSz1Ux6qsLwZg8DkJF3kelbp5JVkInG4kiWJY/1sQrtw7qw6+RWLhjW8fu+FaxJcKFHvUEcjDuDTxU35uz8hXP6PczZt4KNiV482eY1DsadoVoVd9s9xZ2PxaB1RG92AkCr0RJevT5pORfQajQcjk+0FbJn008T4l0bg67oz3Q934Ys3b+ArvX6lBkrT2P/5mw7sZG+jeQzSCGEEELcfaSQvcstjElk0spYkjLyaZdZwLqj5xl5TSH7/eTveOCJB4lo2girxcozw57EVGiyxQ32V4o2VQWl1E2ki5ZUcu37ptd5/1Rvp8dUaLIVvWVxdXdl9CtP2o4/f+dTql+adS0r5uXtRVSrpuj1evR6PRFNG3HyeLytkDWZTNhdM5N62dXPzdfdgSdbNsfX3kLMkZMs37KXD54det1i1lho4uipc2Qt22I7V2A0cS41w1Z4Nm9QVKh6e7jiZG/gYlYOqqpitVptRSyAs6N9hfq77FD8WdpEhqHTFRXzbRuHsfvISTo2q1fWI76upvWC0GgUHO0N+FZxJ9NqpdBkLpaPipUMx+10dB3CwHbtKTDl88nytwmsElJ0D8YG/LdH0Wvvi/fOY9XhJfSoNxBrtg8/r5mDc94JMnPyMLol0K1RJ5JOgZODAYNej0ajwcneDvT5PNvxDRQ0vDLrBWJOxVC9SkcydHupXa0uT3Z5jLScVN5L/i/JqRk4GPRUq+LO1D/W0iCkZpnv0A5pMhJnexdbfptPrAJg47E11PONoEeD/hw5mciMc+tss/EhNXzYG5uATqvDUxdMYsZhxn+/ABUz6a4HsctoDcDqw0tw0DvwWvf3AHj5h3c4nLqVJoQyL3omtX3q0KNBf1bs2MHSuKm2nOr4NuCdflHMXb2Do6fj+Dn9OxoHPsiF3CRikw8xfsAk5q3eSeyJ03x7bg3hgb5kX/rQA+B4yhG8HHzBWPJ+FUUhPSvXduzvGcDWuPXkFGTjYOfIntM7uJibWm4MsP2uVVSa1GpB5zo9bbPNgVVCWBgzB1lMI4QQQoi7kRSyd7GFMYm8vuAA+aaid04tVpUpa47jUtWH/pFXvqo3PzePKj5FM0gbV23AYraU2h8U7XS8bP4SOvbqhE6nY/uGbbZY3Yh6LJz1Jx16dMRgb2Dzmk3Uiahbaj9+tWqQnJiMi1v5s7I5WTk4ODmg1Wo5FHOQ5MRzNGvbvNxYs3bNObT3EM3aNcdisRB74IitiAVIPnsO/+CSBc61zy0xI5+P1yTw8cAGjHmkPm98+TtHTyURVTeo1HytRdU+7zw5EN11NsfS6678q6NoFKzW6+9dVpH+bErp5nofPFTEtXmWls+5zEQ+Wb6Kozmr+WjZagDMVjPJWUkYqE6B7gwTlo/DYjFjtBip6lKNFVv3YzD7Yucczdj7ezB7xVYO5W2hkX8USacOoLn6AxBFwc+5Nnpt0TuddqoHGflF7ykXaM4T7FE0++zlXAUvQ1Fhr9FoGDd6AMdPJ3PkZCLvfvcH+JZ+jztObmbXqa22/NztqwC+hFQN5889szBbzdir3thpr3zocvXvzMe+DqmuS3h32EC2x29i75m6PDvicQAOJMZQYMon5syuoudiuMjF3KKi+VjKEYZEjQTAyc4NR6rZ+k/NPs/iffPJIB3nWlqyM4yY1Xz8vWpwOD+a+XumE1a3LoO79MfR4MSMxRvxreJhuz497yL2OieulLZXqCrY6a78OQqrVo92tTvz1bpP0Gn1hFWrh1ZzqNyYq4M7Hw74Ahd7N7ILMvlu/ec42jnROqT9pbgbGXklNpcXQgghhLgrSCF7F5u0MtZWjF1WYLYwaWVssUJ22GP38+UHX+Dh5UF4g3AcHK8/SxrZojHxsSd476W3cff0ILB2EIXGQgAimjXibMJZPv5v0TtzgaGBxd5JvVrjFo05FHOQ0Lq1gaIly9Om/EBBXj4A2zdsZ9QLj1Enoi4nYuOY+9McNBoNLm6uPP/Wi+jtimZSy4q1uK8lp08k8M7zb4GiXHoXuGimTFVVjh44St/7+5X53OwwY69YyDIZmLQylnZBbmTn5uPtcf0C3MFgR23/6izdtJd+7ZsAkJaZg1ajwd3F8brXVa/ijkajYefBE8WWFjs72le4v3rBNdgSE2u7fktMLE3qlV5wX5tzocmMxWJFqy3+9dCXZ6e9cy5SNbSQrSfSi+WjqiqOeieeaftmiXzW7ttMgd1Jnu0wERd7V3ad3MqWuL/JKzTi6eqKu0djNsauZ9/ZvVT3DbItYb2WRrn6PzUKKlbbUfThU3SIbIzZYiE9K5eQEHfyjYUYC02EB/oSHuhL3JkUTl1q//0f62hSJ5AmdQOJOx/LpuNreaXr27b8/j66BoBI/6YEVgnhyLkDbDiynmz7fIo2TS+ubb0m7F2/nJ1xO9l+ciPtw7pxKukCAb7eqKrKsKYPE1ataEZ86h9rqVvV76qrS/+Q4ect39C7/hAi/KPQ6TS8NOcx9scl8N7oEQx0as7BMwc4kXqUv/b+zsgm/2H3kVPFdlS209qRrZYyHQtYVSs1q1Updq5DeDc6hHcDYHfCDnzcfMuN6bV69NqiF49d7N1oGtiK+AvHbIWs2WJCr7NDCCGEEOJuJIXsXSwpI7/Y8eaQHgDkXXO+dac2tO7Uxnbc74Eru9pO+vHTYm0VRaH3sD4MfmQoVouVX776ieCwK0thew3pTa8hvcvNrW2X+5j45gR6DemD3k5PWIPwEmNdFtG0ERFNG91wTKPRMPzxa7/JqciB3fsJrRuKu6dHidjVz00BArSZ2CsWrDkKn/2aysBOzYpt+FSaJwd3YvaKrbz11VwA7A16RvVvX2Yhq9VqePGB7sxcsplF63ejKArdW0fQulHtCvfXPqoOKRczeefb+QDUD6lJ+ybX38zqMmdHe1o0DOGtr+fi5HBlZ+PtJ9L4Ytt58k0WvHVgvTSr/2rnpiSdPclbX81FxUqOm4kd8ZvoFlFU8CRnJuHm6IHRnI+pUGHcVwsBFbPnHhwd7BjRowFf/76KgtMWjM6rMXgq+Dp2LCPD0hms3uhcU5g4fTEXc1KxVrmIX1VP8gsK+WrOKgrNZlRVpVZ1by5PT55KukDnFkWba+UX5uKgd8TJ4IzJYmJb/EZb3+ezU6ji7E3L4Hbk52hZmD6z1BzCAnxp4t+aOdt/w6LkcyH2BM3qaQjw9aZhjcasO7KCwCqh2OnsiKjtx7YjB2kbGU6oTx3WHlrN5g1GCq05qNWTWLB2J0pODfIL88DiwLhv5mFxOIPFyczIHq3Q2VkwmcHTUIvZW2LJ9zAzc+VqnhzcCw/XovdhL6RnsXHHGSy6i5jOq7w8eSb9O0Rx36U/BxaLlai6gcXuITM/AzcHd/KMuaw+tJgeDfqXG8suyMTRzgmtRkeh2ciBs3uo73dl1+vkzCT83P1v+HcqhBBCCHEnKHfr17lGRUWp0dHRlZ1GpWo9YR2J1xStAH7uDmwZe+NFw2VffvAF6WnpmAoLCQgJ5MGnRlToXddrHYw5iJe3l+2d1jtp1+ad1K4XhptHya1sb9dzuxdd+yw6hC1Co1jRKBqquhRt+PVmr4/JMWYzf/evpOddxKpacbV35bE2z+Ng58gvW77lbHoC7o4e+HsGkpAWz0td3rT1+e6iV4v+2ffKTtlTVn9Ipzo9aVAjkhnbpuLvGUT7sC4AxY7Tc9OYvm0qecYcfFx9KTDnE1WrJc2Drnwwc9mzv43E1d6d3HwjLo722OkMvNV7wnXzW3Hpa2d0Gh0K0CdiCPX8Ikp9TnnGXN7483nahHRkcNQI23mL1czS/X+y/+xuFKVopjs7qRpjhz+Gqim4bu474jezdP8fuDl6Elo1nM1x6/hv9/HkFuYya8ePWK0WLKqVutUbMKDx/WiU4rPoWfmZTF71Hu/2nWyLfbL8bdJy0sg1ZuHu6EFd34Y82KJoCfSHS17HiorVaqFd7c62GdiyYntP72LJ/j/QKBosVgv1/RrRr9EwNJqi8WZu+4E61esTFdASIYQQQlQORVF2q6oaVdl53I2kkL2LXfuuJ4CDXsvHAxsUW1osipPndkXg2KWlvXaLApycUPqy8Tup0FyIVqNFq9GSmZ/BxOVv80Ln1/FxvfMfjlRUfOJ5LBYrtXw9b2vus3b8RF3fhjSqeeX/XQfjzuDh6oRfVc9bMsb15Biz+d+aj3mt+3h0Wlm4I4QQQlQWKWSvT/6Gche7XHRdvfvumG5h/++KsRslz+0KX3eHUmenfd1vfAb+driQncz0bVNBVbFYLfRsOOCuLmIBgvyqApCYfvq25t4nYjBHzx0sdu7aXa5vl7ScCwxv9ogUsUIIIYS4a8mMrBD/YjI7LYQQQghx75IZ2euTj9uF+BeT2WkhhBBCCPFvJIWsEP9y/SP9pHAVQgghhBD/KprymwghhBBCCCGEEHcPKWSFEEIIIYQQQtxTpJAVQgghhBBCCHFPkUJWCCGEEEIIIcQ9RQpZIYQQQgghhBD3FClkhRBCCCGEEELcU6SQFUIIIYQQQghxT5FCVgghhBBCCCHEPUUKWSGEEEIIIYQQ9xQpZIUQQgghhBBC3FOkkBVCCHHXiXqzIa3fbUbHD9vS8cO2jJv3RqXlMmnJBArNhdeN5xRk8+bcsTR/uzH3vd+KDh+04flfniYpPfEOZlncwTMHeOjbB2zHT/80moZj6+DztAe5BTnF2s7e+hvtP2hNu/EtGfHNcNJz0ysUu+zFGc8V6/dI4mEe+GrIbbozIYQQoogUskIIIe5K00b/wro3N7HuzU28P+SjG7rWbDGXOGexWv5RHpOXfoLpOoWsqqo8+PUwzBYTG8ZtZcO4rax5YwNRQU05nZrwj8a7FT5c+B7Pd3vJdvxAq5GsfWNjiXbHzsUyYdGHzH/xLza+vY3GAVF89Nf4cmOXrdy/HEVRip2r41cXvc6OzbGbbsOdCSGEEEWkkBVCCHHPOJ91nke+G0H7D1pz3/utmLt9ji0W9WZDPls2iQGf9+HVWS+z5dhmOn7Yltd/f40en3Rh7aHVZOdn8fLMF+g2oRPtP2jNm3PH2grcyUs+sc0Cd/qwHZl5mYyd/SoAvSZ3o+OHbcnMyyyWz8ajGziTdpoPhk7AXm8PgFaj5eF2o2gR2gqAAZ/1ZtWBFbZrrj4e8Flv3pn/Fn0n9yDyjXp8s/pLFuyaT69JXYl6syGLdi+0XefztAeTlkyg16SutHqnKUv2LCr1GZ29eIa4lDiaBjWznWsb3g5vV+8SbY8mHaF+zfpUcakCQOf6Xfhj5/xyYwAXcy7y6dKJjB/8QYl+B0QN4rctM0rNTwghhLgVdJWdgBBCCFGax394BIPeAMC4Ae/SoW4n3pw7lnDfOvzy1K+kZCbT+aP2NKjZkDp+dQFIyUzmz5cXA7Dl2GaOJB7mk/s/5eNhEwF4eeYLtKrdis9H/g+r1crTP49m1tZf6RPZj2/WfMWhicdwsHMgpyAbe70DE+6fzM8bf2TpqytxsncukeOBM/to4B+BXqv/x/eZlJHEwv8s5XxWCi3ebsITnZ5m6ZhV7Dm1m1FTH6Jvk/62thpFw9Ixq4hLPk7vyd1oHtKyRIG67fgWIgMaV2jsejXqszdhLwmpCfh7+bNg13xyjTmk56aXGfNw8mDsnFd5tfd/cXVwK9FvVFBT3pr3+j9+JkIIIUR5pJAVQghxV5o2+hdbgXrZpqPreW/Q+wD4uFWjc/2ubDm22dZuSPPhxdoHVQ0uNjO5cv9yYhJ28+2arwHIL8zH190XFwcXQnxCePbnJ+lQrxNdG3TD2d7lhnPecGQ97y0YR05BDo+0G8UzXZ4v95q+jfuh0Wio5l4dD2cPejbqDUCEfyPOZSRRYCqwzfY+0HoEACHVQmlQM4LdJ3fRPaJnsf6S0pPwdq1aoXyDfUL4YMjHPDFtFIqi0ONSXzqNtszYot0LsdPZ0bVB91L7rerqw4Ws85gsppsq8oUQQojrkUJWCCHEXWFhTCKTVsaSlJFPYU4B646eL1HIAiXeybz60MngVCx27TGo/PLkbwR4B5Tod9lrq9l5YgebYzfS5eMOzH5uHvVq1C8z5wY1G/LzhmmYLWZ0Wh331WnPujc38e4f48g15gKg1eiwWq22awpMxmJ9XJ51BtAqWgw6w6XrtABYLGYopRZUVbXEswCw1ztgNBWUmffVBjQdxICmgwDYc2o31Tf8iIuDa5mxLcc2sTl2E1FvNrT10+79lsx6bh5h1cMxmgrQa/VSxAohhLht5B1ZIYQQlW5hTCKvLzhAYkY+KmCxqkxZc5yFMcV3/m0b3p6Zm6YDcD4zhbWHVtO6dtsKj9O1YQ++XDXF9l5sWk4aCakJ5BRkk5aTSqvarXmtz+uE+9bhaNIRAJztXcgqyCq1v3bh7anu7su4+W9QcFXxmF+YZ/s5wDuAvQkxAMSeO8qhswcqnO+1Zm+dBUD8+RMcOnuAxgFRJdrU8avLiZS4Cvd5PjMFgAJTAZMWf8zTnZ8rN/bJ/Z+y9+NDRH+4n+gP9wOwcdw2wqqHA3As+Rh1/er9gzsUQgghKkZmZIUQQlS6SStjyTcV31XYaLYwaWUs/SP9bOc+HDqBMbNepv0HrVFVlbf6v0O4b50Kj/PBkI8Yv+AdOnzQBkVRMOgMvD/kI/RaHaO+f5gCUz5Wq5WG/hH0iuwDwNOdnmXQ5/2wt7Pnz5eX4OZ45Z1QRVGY/dw8Plr0Ae3Gt8TR4IizwZlgn1AGNxsKwHNdX2L0D4+w7tAa6vjVo37NhqXmVhEGnR29J3XjYs5FJj3weakbODUPbsHptASy8jNt768+OnUkMaf2ANDq3WaE+9bh9xf+AODFGc9y9uJZCi2F9G8ykNEdnrT1VVasLOsPr7M9PyGEEOJ2UFRVrewcShUVFaVGR0dXdhpCCCHugMCxSynt/0YKcHJCrzudzl3J52kP4j8/U+qmU9f6YsVnGPT2PNXpmTuQWXGF5kK6f9KJeS8uxMvZ646PL4QQ/yaKouxWVbXk8hshS4uFEEJUPl93hxs6L8r2VKdncbi0QdSddvbiGd7oN06KWCGEELeVFLJCCCEq3ZhuYTjotcXOOei1jOkWVkkZ3X1Svk2v0GwsFG0g9XC7Ubc5o9IFVQ2mc/2ulTK2EEKI/z/kHVkhhBCV7vJ7sJd3LfZ1d2BMt7Bi78cKIYQQQlwmhawQQoi7Qv9IPylchRBCCFEhsrRYCCGEEEIIIcQ9RQpZIYQQQgghhBD3FClkhRBCCCGEEELcU6SQFUIIIYQQQghxT5FCVgghhBBCCCHEPUUKWSGEEEIIIYQQ9xQpZIUQQgghhBBC3FOkkBVCCCGEEEIIcU+RQlYIIYQQQgghxD1FClkhhBBCCCGEEPcUKWSFEEIIIYQQQtxTpJAVQgghhBBCCHFPkUJWCCGEEEIIIcQ9RQpZIYQQQgghhBD3FClkhRBCCCGEEELcU6SQFUIIIYQQQghxT5FCVgghhBBCCCHEPUUKWSGEEEIIIYQQ9xQpZIUQQgghhBBC3FOkkBVCCCGEEEIIcU+RQlYIIYQQQgghxD1FV9kJCCGEEOKKmVO7oNUZ0GrtsFgKqV6jMe06j0Or1XNw7+9YzAVERD1cob4WznmERk0fISC4/e1NuoLm/zoci7kQq9VExsUEPKuEAODtU4ewev3Yun4yQx6ae9PjbF43gep+kQSHdSM15Qgb13xA6vmj+Ae1pXu/KbZ2psJcNqz+gNTzR7BazdRpMIjIZo+WGwM4m7CdbRs+w2wuAKBL74lUqRrOwZjZGI05NGkx+qbvQwghxPVJISuEEELcZbr1/Rwv71CsVgt/zn6I+ONrCA3vQf1Gw657jdVqQaPR3sEsb9zgEXMAyMpMZP7MoQx7ZIEtlnh65y0ZIyc7mbMJ22nd4b8AODh50brDf0k9f5QzCVuLtd29/Qe0Wj3DHvkTsymfBbMepHqNxlTzjSgzlpOdwt8r36b34Kl4eAZiNhVgtZoBqNNwMLN/7EODyPuxMzjfknsSQghRkhSyQgghxF3KYjZiMRsxGFwB2Lnla0yFebTuMIajB//k+JHlODh6kp52gg7dxqPR6lm34i2sFjMeXsFYzEZbXznZKWxe+xEZ6acBCK3TkyYtRnPs8BL27/kVq8UEQKv2Y6hRqwUASWd3s3H1+4CCn38zTsatpdfAb/HyDiX94km2rJtAfn46VouJhk0eok6DATd1v1armfUr3yU5aR+KAl36TMbTKxiAowcXcnDvHFSrBTuDM+26vI2HZ2CJPo4e+JPg2l1RFAUAJ+eqODlXJf3iiRJtUy/EEl6/P4qioLdzxLdmU44fXkI134gyYwf3ziGsbh/b+Dq9va1PrVZPzYBWxB1dTt2IITf1PIQQQlyfFLJCCCHEXWblopfRau3IyjhDzYBW+Ae2LrXducQ9DHt4AW4e/gDMmzGEBo0fJLx+f5KT9vHnrBG2tmuW/pdaQe3o3v8LAPLz0gHwD2xDaJ1eKIpC+vGQK8EAACAASURBVMWTLPr9MR5+eh0WcyGrF4+hS59J+NZoQvyxNRzY8ytQVHCuWfIanXt9godXEIWFucyfMZRqvhF4eAX94/tOTztBxx4f0r7bu0Rvm8rubVPp0nsiSWd3Exe7kgHDZ6DV2ZEQv4m/l7/FwAd/K9FH4pldxZYAl6WqT11OxK4iMKQjhcYczpzcgrtnQLmx9NQTuLj58tfvj2IsyMKvZjNatHsZrc4OAB/fCE6f3CSFrBBC3EZSyAohhBB3mctLi81mIyv+eol90TOIiHqoRLvqfo1tRWyhMYe01OOE1esLQDXfCDyrhAJF73smJ+2l79BptmsdHD0AyMw4zY5NX5Kbk4JGoyMvN5W8nAvk5V1EpzPgW6MJAEG1O9tmhjMuniI9LZ5Vi1+19WexFJKeFn9Thay7ZwDePnVs+SecWA/Aqbi/STsfy/xfh19qqWIsyCq1j9zsFBwcq1RovMjmj7Nt/WTmzxyKg4MnvjWbUpCfXm7MqppJToyhz9Bp6HQGVi95jT07p9G01TMAODpVISc7+R8+BSGEEBUhhawQQghRyRbGJDJpZSxJGfk87VnAuqMpDPEORaczEBB0H6fiN5RayOrtHIsdKyg3PPbqxa/RqsMYgkI7oapWvv+8CWZLIaCCcv3+7B3ci73jeitotQbbz4qiwWq12I7rNBhAszbPl9+HzlBsSXVZ9HoH2nUZZzvesHq8rRAvK+bi6kvVavUxGFwACAnrTuyhRba2FosRne7KcmMhhBC3nnz9jhBCCFGJFsYk8vqCAyRm5KMCFqvKlDXHWRiTiKpaSTobjbtHrXL7sTM441kllGOHlwKQcm4/F1OPA6C3c6KabyP2Rc+wtb+8tNhozMLVzQ+AI/v/wGIpBMDDMwizKZ9zZ/cAcPL4OozGollQd88AdHqHYsVbelo8hcYcANYsfZ34Y2tu5rEUExDcnthDi2yznFarhfPJh0pt6+Vdm4z0kxXqt9CYg9lUtOtw6vlYTh5fS/3I+8uNhdbpReLpnVgshaiqyulTW/CqGmbrNz0tHi/vMIQQQtw+MiMrhBBCVKJJK2PJN1mKnevuMJ2Dq2eTH2PAs0ooUa2erlBfnXp+xLoVb7Evejre1eriU72hLda51ydsWvMBc37uh6JoCK3Ti8bNH6dNx7EsX/gCTs5V8a3ZFHsHdwC0Ojs6957IhtXj0ent8fNvjoOjF3YGZzQaHT0Hfs3mdROI2fkzqmrB0cmLrn0+A+BCyiEaNH7gFj0h8K0ZRfO2L7JswXOoqgWLxUxIWFeqVqtXom1QaGfiYlcQXr9o46mszET+nDUSszkfi7mQ6d92pGnrZ6nbcBBZGWdYufgVNBotWq2Bzr0+wcm5atF1ZcSq+0VSK7Atc6cPQlG0ePvUoUnzK1+3c+bUFpq3efGW3b8QQoiSFFVVKzuHUkVFRanR0dGVnYYQQghxWwWOXUpp/ydWgJMTet3pdIopLMzFzs4JgMTTO1i77A1GPrkaRbn+gq6C/AxWLX612Pu4d5LVamH+zGH0GvQtTs7ed3z89LR4Nqx6j/73T7/jYwsh/n0URdmtqmpUZedxN5IZWSGEEKIS+bo7kJiRX+r5yhZ/bBX7omegqipanR1dek8qs4iFondnK6uIBdBotNzX9R2yMs9WSiGbk51c7N1aIYQQt4fMyAohhBCV6PI7slcvL3bQa/l4YAP6R/pVYmZCCCEqm8zIXp/MyAohhBCV6HKxennXYl93B8Z0C5MiVgghhCiDFLJCCCFEJesf6SeFqxBCCHED5Ot3hBBCCCGEEELcU6SQFUIIIYQQQghxT5FCVgghhBBCCCHEPUUKWSGEEEIIIYQQ9xQpZIW4QauPrmH4zyMY9vODDPhhCK8veqvca3p+24+4CydKjT037yXOpJ+94Twen/UUG+M2lfj5RiRlJvH4rKdu6Jrr3UtF7uO7zd9jspiuG7eqVh79dTQpWSkALD20nKE/PUDUxJbM2T23WNtTaQk8Mftphv70AEN/eoDtJ3dUKDZt608M/ekB2+9w5ZHVtth//3qDvWf3l/0AhBBCCCFEpZNdi4W4ARdyUvlo1URmPzKTaq4+qKrKsfPHb6rPr4ZMuUXZ3Riz1XxL+6vIfUzdMo2Hmo1Ar9WXGl99dC3BVYLwcfUBIKxqbT7u+wE/b59eou07y8YzJHIQvev3JOHiaZ6Y/QwLn5iPg96+zNiwJkN5vNUoAM5nX2DgtKG0DGyOq70ro1o+wsQ1n/LjA1Nv4kkIIYQQQojbTQpZIW5AWm4aOq0ONwc3ABRFIcynti2+L3E/U/7+ktzCXABe7vACLQNbALDq6BrGr/iQ1Jw0Hmr2IMObDAWKZjj/N/gzQryDeXzWU9SrXpf9iQe4kHOBLuGdebH9cwCcSI3n3WXvY7aaCfIKpNBcWGqOOcYcPl03heMX4ig0FxLl34RXOr6EVqPl8VlPEeHXkIPnDmKnNfBmt7G4ObgCRbOYby97jwJTAVbVSt/6vXmo+YgKP5ur72Pq5h9YcWQVdjo7FBR+uP9bvtr4LQCP/Po4iqIw7f7vcLF3KdbHgn1/MrrV47bjEO9gADRKycUjxy4cp1VQSwBqefrj5uDKlvitdA7rWGbMxeBs6yPflIdC0UwwFBXO6bnpJFw8TS1P/wrfuxBCCCGEuLOkkBXiBtSuGkr96nXp+W0fmtRsQmSNCHrV74G7gzuZ+Zm88udrTO4/kUY1GmKxWmwFLUCBqYAZI38iKTOJwT/eT98GvXG0cywxRnJWMj8+OJXcwjz6Th1A/4Z9qeXpz7gl7zK8yVD6NujN/sQDPPrb6FJz/HTdFJrUbMw7Pd7Cqlp5Y/Hb/LV/MQMb9QcgLvUEXw/9HzpN0b/+nw6YCMDcmPm0CWrNE60fAyCrIOsfPaOsgixm7PqNtc+twF5vT64xF4PewOtdX2NuzHx+GTGt1Ps2WczsSzxA/ep1KzROHZ9wVhxeyQNRwzmcfIRTFxM4l3mu3BjAvJg/mBU9h+TsFN7tMQ53B3dbrKFfA3Ym7JJCVgghhBDiLiaFrBAVsDAmkUkrY0nKyMfXvScPtxqIm3Mifx/bwPSdvzJv1Cz2Jx0gyCuQRjUaAqDVaHG1d7X10a1OFwB83XxxtXchJfs8gV4BJcbqHNYJjaLBxeBMoFcAZzMS8XLyJC71BL3r9wSKiq3Ls5XX2hC3iUPnDjNz129AUQHt41LVFu9Rp5utiL1a45qRfP73F5gsJprWakJT/6h/9Kyc7Jyo5enPm0veoXVgS9qGtMHJ4FTudRn5Geg1Ouz19hUaZ3yvd5i89nP+OrCYIK9AImtEoNPqyo0BDIkcxJDIQRy/EMebi9+meUBTWzHr5eTF+ezz/+DOhRBCCCHEnSKFrBDlWBiTyOsLDpBvsgCQmJHP56sL+XhgK74bPoSB04YRfXoPem3Z/zoZdAbbzxpFi8VquU47u2vaFb3LqqBUKF9VVfls4CRquPuVGne0cyj1fOewjjT0bcD2Uzv4efsM/tq/mA/7jK/QmFfTarTMGPkTe8/uZ1dCNA9Mf4ivh3xB7aqhZV5nrzNgtJS+XLo0Ndz9mDJosu144LRhBHoFlhu7Wqh3CN7OVYg+vYfOYR0BMJqNuF9aOi6EEEIIIe5OsmuxEOWYtDLWVsQqShZa7RnyTRYmrYwlJSuF9Lx0/Nx9ifBrSHzaSfYlFu16a7Fa/vHy3Gs5G5wJ9g5i+eGVABxMOnTdXZDvC2nLz9un2wrl9LwMEjMSyx3jdPoZqjh70bdBb55s/TgHzx36R7nmGnNJz8sgyr8xT7d9gpAqwZxILcrVyc6JHGNOqde52Lvg5ehJUmZShca5mHsRVVUBWHRgCXZaPc1rNS03Fp960tZHYkYiR1OOEXRVkXsy7VS5RbcQQgghhKhcMiMrRDmSMvJtPyuKFQeH9Wg0mWRbdDw/34Vn2z1FuE8YAJP7T+TTdVMoMBWgKAovd3iRFgHNbkke7/d6l3eXvc+vu2ZRxyecBr71S203ptN/mLL+S4b9/CAKCnqdnjGd/oPfdWZoL1t9dA3LDq1Ar9WjKApjOr1y3bZP/f4sWuXKfz7mPTbL9nOOMYdXF47FaDZiVa2E+4TRsXYHAEY2fYAn5jyDQWcodbOnDrXbs/XkdgY3GgjA8sMrmfL3l2QZs1h/fCM/b5/BN8P+R3CVINbHbeSXHTNRgBruNfhs4EQUpWjWuqzYd5u/50RqPDqtDq2i5bXOrxBUpaiQzS/MJz41nqaXil4hhBBCCHF3Ui7PWtxtoqKi1Ojo6MpOQwhaT1hH4lXF7GV+7g5sGduxEjL690rMSOT1ReOYPvJHW+F5J83fu4CUrPM82+7GvltXCCGEEOJ2UBRlt6qq/2zjkn85WVosRDnGdAvDQa8tds5Br2VMt7BKyujfy8/dj5HNHuBCTmqljK9RNIxq8XCljC2EEEIIISpOlhYLUY7+kUVLcq/sWuzAmG5htvPi1uoS3rnSxh4Y0b/SxhZCCCGEEBUnhawQFdA/0k8KVyGEEEIIIe4SsrRYCCGEEEIIIcQ9RWZkhRAVNmTag9hp7bC79F23kTUjeKH9M2Ve8/zc/zA8aiitg1rw4YqJhPvUZlBkySW8Q6Y9SKHFxILRs9Fqit5JXnpwBRNWTealDs+Vek1FLTu0kvq+9fD3qPGP+3jjr3c4l5UMQNyFEwRVCUSjaPBwdGdM55cZ/dszLHlmwT/u/7J5exZgtpq5P2ooF7JTeX/5xxw7f5waHjWY9uA3tnYWq4WvN0wl+vQezFYzrYJa8Gy7J1EUpczY/D1/svTQCls/SZnn6F2/B8+3f5pt8TvYfGIrY7q8fNP3IYQQQghxO0khK4S4Ie/3edv2dTW3mpeTJztPRdMyqDkAKw6vIsyn9k33u/zQStwc3G6qkP2o33u2n9t+1plvh/8PRzsHAM5lJt90jgAFpgLmx/zJjIemAeBgZ8+oVg+TW5jHz9tmFGu79OByTl1M4KcR34GiMHbhW6yNXU/n8A5lxgY3HsDgxgMAMFvMDPh+OF3Ci3bfbhnUnGlbfyExIwk/d99bck9CCCGEELeDLC0WQty05+f+hy3x2697XFE963Zj+eGVQNFModFkJNArwBbPK8zno5WTeGj64zw0/XF+2zmn2Jhfb5jKM3NeZOiPI/hu0w9A0axubMoxvvj7Kx6d+STRCbt5aPrjHEk+art2zu75TFz92Q3ne63vN//EqJlP8sDPj7A/8YDt/Lb4HTw950Ue+/Vpnpr9PIeSDpd6/frjm4io0RCD3gCAs8GZRjUa4qi3L9E27kI8Uf6N0Wl16DRaomo1YfXRteXGrrYlfhueTh6EV7uyA3fH2vex9OCKEm2FEEIIIe4mUsgKIW7IuMXjeXTmkzw680l2nNp1S/uOrBnBiQsnyS7IZvmhVXSr26VYfPr2X1FVK9Mf+oFvh3/BiiOr2X5ypy1+Pvs8Xw37nJ9GfMeSA8s5k36WXvW7E+ZTmxc7PMfPI6cSVasJAxv14899iwFQVZW/9i1mYKN+N5V7ZkEW9Xzr8tPIqTzSYiTfbiqaVU3MSGL6jl+ZPOAjfhzxLf/t8gpvL32/1D72ntlH3WrhFRovzCeULfHbyDflk2/KZ3PcFpKzUsqNXW3pwRX0qt+92Ll6vnXZfXrPjdy6EEIIIcQdJ0uLhRA35HYuLVYUhQ6172NN7N+si13PN8OncDTlmC0efXoPL3Z4BkVRcDI40TmsA9Gn99AisBkA7Wvfh0bR4GxwppaXP0kZSdQsZTlx97pd+GX7r2TlZ3Ek+Sgeju6EeAffVO4OegdaB7UAoF71Ony94TsAdp7aRWLGOZ6b+x9bW4vVysXcdDydPIr1cT7nAq0cW1RovB71upGUeY5n5ryEk50j4dXCiDmzr9zYZak5aew5s5c3ur9W7Lynk2elfY+vEEIIIURFSSErhCjTwphE23fo+nkXsO7IeYLaFi9ktRotqmq1HReaC//xeD3rdeWJ2c/TqEZD3BzcisVUVEApdk656vjyJlQAGkWD+aqcrmavt6dLeEeWHVpJzNl9Nz0bC2Cn1Rcb22K1XMoZmgdE8VaPseX2YdAZKLRU7NlpFA2jW49idOtRAPy263dqefqXG7tsxeFVtAhshvs1z7jQXIhBZ6hQDkIIIYQQlUWWFgshrmthTCKvLzhAYkY+KmCxqkxZc4yFMYnF2vm5+XI0ORaAk2kJxF048Y/H9HX35YnWj/JIixElYk39m7Dk4HJUVSWvMI+1seuJ8o8st08nOydyjbnFzg1o1Jd5exYQm3Kc+0Lb2s5/t2kaf8Qs/Mf5l8i5VhN2nIrmZOop27mr38+9WnCVQE5fPFOhfo3mQnKMOQCkZKWwcN8ihjUZXG7ssuWHVtGrXvFlxQAJFxMI9g6qUA5CCCGEEJVFZmSFENc1aWUs+SZLsXNGs5VJK2PpH+lnO/dg02GMW/I+20/tIrhKIKFVQ25q3L4Ne5d6/uEWI/h83Zc8PGM0AN3qdKb5pWXFZenTsBffbJjKnOi5PNPuCaJqNcHXrTr+njWpWz0c/VWzqSdS42/JTsmX1fSowbgeY5mwajJGcyFmq5n6vvWoU8q7sO1C2/DZ2v8xqtXDQNFX7Fz+WqJcYy4Dvx9O7/o9inYyNubywv+xd+dhVVX7H8ff6zCjKCKiMigIivOIQzlPmVlqZZPl0GylzZbm/VX3ZmV5u81z2Vxa5pBDmmNaaopzoqDiiChOoDLD2b8/wJMmk4rQwc/reXrk7LX2Wt+9oAPfs9Ze+4cnMCZvRnpE53uIrFkfoMgygE0Jf5KWlUa70KhzYli9O5puZyT2IiIiIv9ExrKsCz/ZGD9gChAK7AZutizr+N/qtATeB6oAucCLlmVNKa7tqKgoKzo6+oJjE5GLFzZmDgW9Qxhg14R+ZR1OqUrNTOX2z+/io8HvEOBTAwC7ZWfEdw/zwW1vYTPls2Dl8R+fZkTne2gQUL/4yqUsJT2FR34Yzce3v3tWci8iIiLlwxiz1rKscz95loteWjwGWGRZVn1gUf7rv0sDhlqW1QS4GnjDGON7kf2KSBkI9PU6r+POYsbGWQz54m5ubTPIkcRC3r2lHw1+p9ySWIDHeozi6Klj5dL3gZREnuj1iJJYERER+ce72BnZWKCbZVmJxpjawFLLsiKLOWcjMMiyrO1F1dOMrEj5O32P7JnLi73cXHj5hmZnLS0WERERkdKnGdnCXew9sjUty0oEyE9mA4qqbIxpB7gDBe4EY4y5D7gPoE6dOgVVEZEydDpZPb1rcaCvF6P7RCqJFREREZFyVeyMrDFmIVCrgKJxwBeWZfmeUfe4ZVnVCqjL6RlbYJhlWauKC0wzsiIiIiIicjnTjGzhip2RtSyrV2FlxphDxpjaZywtTiqkXhVgDvCvkiSxIiIiIiIiIoW52B1NfgKG5X89DJj59wrGGHdgOvClZVk/XGR/IiIiIiIicpm72ER2AtDbGLMd6J3/GmNMlDHmk/w6NwNdgOHGmA35/7W8yH5FRERERETkMnVRuxZfSrpHVkRERERELme6R7Zw5fewRBEREREREZELoERWREREREREnIoSWREREREREXEqSmRFRERERETEqSiRFREREREREaeiRFZEREREREScihJZERERERERcSpKZEVERERERMSpKJEVp/X4yOt4+vEbGffUbTz5yEBen/g422M3XpJ+9u/bcc7xrVuiGXprFN99/eZZx1/6930MvTWKjIy0Uun/0MF93De8C7m5OQBYlsVD9/U+q9/VqxYy/rl7im3rzLgKu67FC6Yyb843pRL7mb754jVWr1oIwJ7dsbzw7F3cM7Qjb//vqbPqZWSk8eG7z/LM6Ft4+vEbmTvrqxKVLV86ixF3deNfTw/mX08P5s3XnnSUTf7mTVb+Pq/Ur0lEREREyodreQcgcjFGPfYKwSERAKxZvZjXXnmE0WPfIbx+0zLpv3ZgXdZFL+WWwSOx2Vw4nJRAVlZGqfZRs1YI3t4+7I7fRnj9piTsj6dGjdrEbl3nqLMtZi2NmkSVSn89eg8qlXbOdOzoIbb8uZrBQx8HoEoVPwYPeZw9e2LZsumPs+rOmv4Zrq5uvPjqZLIyM/jPs3fRoGFLIuo3K7IMoEnTdox6/NVz+r/muqGMf+5u2l9xFTabPr8TERERcXZKZKXCaNuuB/E7tjB39leMeuwVcnKy+WHye8RuXUtOTg7BIeEMv2csnp7erPhtHr/8/B05udkA3Hb7ozRp1g6A2K3r+WLSBNzdPQiv3wwLq9A+PTy9CQoKY/PGlbRo1Ynlv86mY+d+xO+McdT57qs32LZ1HTk52fj4+HLPiGfxr1Gbw0kHeG7cELr3vIGNG34nKzODu+9/lsiGLc/pp2Hj1myNiSa8flO2bV1Hm3Y9+GPlL6SnncLLuzJbY9YyZPhoAH6e/TWrVvxCrj0HNzcPht89hrqhkUWO3c+zv2bj+t95+ImJzJvzDZkZ6dw25FGWL53Fyt/n4V2pCgn7d+LtXZlRj7+Kr68/OTnZfDnpVbbGrKVK1WrUrduAlOSjBSaSy5bOom37nhhjAKjmV4NqfjU4kLDrnLp798bRuet1GGPw8PSiYePWrPjtZyLqNyuyrChVqlQjICCYmD9X07R5hyLrioiIiMg/n6YmpEIJj8ibsQSY89MXeHtX4vkXv2T8K99SrVoNZs34DIBmLTrw3PjPGT/hWx56+CU+ev95ALKzs3jvrWcYMnw0z7/4JQ0iW3L0yMEi++zc9TqW/zoHy7L4Y+UvdOjY56zyawcM598vfcmLr35Hh459mPLtW46yUydTiKjfnPETvmXgjffy/RllZ2rUuA3bYvJmYLfFrKVho9bUb9CC2G0bOHkimaRDCUQ0yEvmOnbpx79f+pLxE77lxptH8PknLxcau91u8dXnE9kVv5Unx76Ft3flc+rEx8dw2x2P8PJ/vycwuB4L5k0BYPHCHzl69CATXvuep8e9x674rYX2sy1mLeERJZslDw1rxOpVi8jJyeHkiWQ2b1zJ0SOJxZYBbNu6jn89PZgXn7+XDet+O6vdiAbN2PLnmhLFICIiIiL/bJqRlQrlzNnT9WuXkZ6eypo/FgN5SWqduvUBSDq0n/ffGsfx44dxcXElJfkoyclHOJFyHHcPT8cy3fZX9Oazj18sss9GTaL4YtIE1q5ZSnBwOD4+vmeVb9rwOwt/+YGMjDTs9tyzyjw9vWnVpjMA4RHN+O6rNwrt45uvXic3N4fd8VsJq9eYY0cPsTVmLVlZGdSLaIK7uycAu+O3MmvGZ5w6lYLNZuNg4t5CY//kw/8QUb8ZD4wa75gt/bv6DVpQ3b8WABERTflzc95S4K1b1tKx8zW4uLji4uJKhyv7ELdtfYFtHDt2iCpV/QqN40zXDhjO5G/e5LlnhuBTpRqNGrfh5MnkYstatu5M+yt74+7uye5d2/jvhIcZ++yHBAWFAVC1anViC4lPRERERJyLEllxKjPWJzBxfiwHktPpkJLBoq1JDMu/RxZg184YgkPCAbAsGHbXGBo3bXtOO++/NY7bhjxGm7bdsNvt3DusE9lZWVDEMuLCGGNo16E3kz4ez70jnj+r7MjhRL756n/8+8UvqREQxPbYjbz/9r8c5a5ubo6vbTYbufacAvsIqBlMpUo+rPhtHgE1g3F1dSWyUSt+nv0V2VkZNGrcBoCcnGzefv1pxj3/MaFhDTl+7DCPPNi30NgjG7ZiW8xaTp44Xmii6e7mfkaMLthzTyfjFlBw8ntOG+6eZGdnlaiuh4cnw+562vH6808nEJifjBZV5lPlrw8QQsMa0iCyBfE7tjgS2ezsLNzcPUoUg4iIiIj8s2lpsTiNGesTGDttMwnJ6VhArt3izYXbmbE+AYC10UtZvGAqV/e7HYBWbbrw85xvHJsvpaenkpB/T2Zq2ilqBAQC8OuSmY4kq3ZgKFlZmWzL30hp9aqFpKWdKja27r1uoN91Q2ne8oqzjqenp+Lq6kZV3+rY7XYWL/zxgq+/YeM2/DR9Eg3zk1ZfX38yMtLZuGGFI5HNzsrEbs/Fr3pNABYt+KHINrt270/fa+9gwvgHOH7s8HnF06hxFCt+m0tubg5ZWZn8sXJBoXWDQ8I5eGBPidpNTzvl+J7t3bOdtWuW0LP3TcWWHTuW5GjjyOFEdm7/k5A6f33IcSBhF3Xq1D+vaxQRERGRfybNyIrTmDg/lvTss5fm1jvwHd+9OZXfqroQFBzGE0+/6dj459oBw5k+9UOee2Zo/k61hoGD7iUoKIw7hj7OG/99kmp+NWjYqDWVfaoC4ObmzoOjXnRs9tSoSVvHstqi+PkF0K//sHOOh9SJoF37Xox98haqV69Jw8ZtiN16YctbGzeO4vdlc2jYuLXjWP3IFqxYPpfw/Gv28q7MDTfdz/PPDKW6fy2at7yy2Hav7NQXNzd3Jox/gCfHFHyPbkF69L6RvXviGPvkzfhVr0VovYZkZRa8Y3NUux6sXrWAzt2uA+Bw0gHGP38PWZkZZGdn8siD13DDoPvo2mMgSUkJvPPGWFxcXHBzc+eBkeOp5lcDoMiyRfN/YN3aX7HZXAAYdOtDhIY1BPIeWbTlzzVcN/DOEl+fiIiIiPxzGcs6/6WUZSEqKsqKjo4u7zDkHyRszJwCF/4aYNeEfmUdjpA34+zlVYns7Cxen/g47Tr0oluPgefUs9tzee6ZoTzx9Jv4VvMv8zg3bVzJiuVzGTHyhTLvW0RERORCGWPWWpZVOs9YrGA0IytOI9DXi4Tk9AKPS/l4ZfyD5ORkk52dSZOm7ejc9doC69lsLtx57zMcTkool0Q2Iz2VWwY/XOb9ioiIiMiloRlZcRqn75E9c3mxl5sLL9/QjIGtgsoxMhERERGR0qcZ2cJpRlacxulk9fSuxYG+XozuE6kkVkRERETkMqNEVpzKwFZBl8XhbwAAIABJREFUSlxFRERERC5zevyOiIiIiIiIOBUlsiIiIiIiIuJUlMiKiIiIiIiIU1EiKyIiIiIiIk5FiayIiIiIiIg4FSWyIiIiIiIi4lSUyIqIiIiIiIhTUSIrIiIiIiIiTkWJrIiIiIiIiDgVJbIiIiIiIiLiVJTIioiIiIiIiFNxLe8AREQuB2vnzyIzLZUrr78VgL1bN7Pwiw+5/rFxVKtZG4AFn79P3SYtqB0eyU/vvMrtz75yyeJZ9v1X+AfXofGVXR3HVs+Zhqu7B61797tk/f5d4s44fv74LZp26Um7a653HJ/74Rsc3LWDIf9+DTcPjyLbWLdgDi2698HFteBfaVtXLmPbquVgbNhzcwhp2IR2/W4oss3t0avYt+1PetxxD4k741g9dzoDRj19/hdYQgu/+JBWva6helAI+2K3sO6X2Rw/eIAmnXrQtu8AR720E8n8Pm0yp5KPY9lzadHjasJbRuWVnTzBb1O/JjUlBXtuDoERkbS/bhA2m63I8/6Y/SMBdcIIa976kl2fiIhIadOMrIhIGahVrz6J8dsdrw/u2kGNkFAS4+MAsNvtHNodT616DcorxAtiz80t0bGiVK1Rk71bNmG32wE4eewIOdnZJT5/w6KfC+3z8L49bPltCdeMeIzrHx3L9Y+NI6J1+/OK71I7tHsndrud6kEhAFSpXoNON95Ok049zqm7ataPBNQN4/pHx9L33oeJ/nkGaSeSAdi4eB7VagXlXeejz5C0dxd7YzYVe16zrr1Zt2AOlmWV0RWLiIhcPM3IioiUgZqh9Th1/CjpJ0/g5VOFg/E7aNnzanasW03jK7py7MA+3Dw8qVLdn5PHjgIQPf8n9m+LISc7i06DbqdWaDgA+7ZtYeOS+eTmZGNzcaH9tTcSUCeMxJ1x/DH7R2qEhJK0dxdg6D74TnwDap13vMcOJrByxvfkZGWSm5NDZLuONOnUHcibzXXz8ODE0cNkpJ5iwKinmTRmJG37DmTftj+pGRbBni0b6TzoDmqE1AXgz+WLSD58iE43DD6nL1d3d3wDapMQt5WQhk3YvvYPIlq348j+PY46KYcPsWrWj2SmnSI3J5cmnbrRIOoKVsyYAsDs91/DGEPf+x7Bw8vbcV5qSjJunp64uefN6tpsNvxqBwF5CfeCz98nIy2V3OxsaoTU5crrbyt0ZhdgxYwp+PhVp1mXXgAcTdjHku8+48Yn/g9jzHmPM0Ds6t8ds6MAVf0DANi9eb0juT/tWGICLbpdBYCXTxWq1Qpk16b1ju9NdmYGlmWRm5ONPTcX7ypViz3P26cKlar6cjB+O7XDneuDFBERuXwpkRURKQOubu74B9clMX47IQ2bkJOVSXBkE1bPngZAYvx2aofXd9TPTEsloE4YUX36s3P9GqJ/nsm1DzzOiaOH2bD4Z/rc9RDunl4cP5TIL5Pe45axLwBw/FAinQfdQccbbmPD4nlsWDyPbrcOLzCmTUsXELdmheN12okUGnboDIBPtepcfc9IXFzdyM7MZNa7Ewlq0MiRFCft3cU19z/qSBABLMvimvsfBaBSlapsW7WMGiFDsCyLbat+o/vtdxc6PvXbtCd29e8ERzZm16Z19BvxGKt++gHISziXTv6crrcMwzegFtmZGcx8+1UC6oRx5cBb2LZqOdc+8ESBS5CDGjRk868L+P6VZ6kVFkGtevWJaNUOV3d3jM1G11uH41mpMpZlsez7r9gevdIxBgVpfGVXFnzxAU0798QYQ8zKZTTq0PmCk1jI+9637NG3RHX9g0KI37gWv8BgTh47QtLe3VStUROAVr2uYfHXn/Ddi8+Qk5lJ407dCKgTVux5AAF1wjiwI1aJrIiIOA0lsiIiZaR2vfocjN+Om6cnNUPDsdlsVPGvwfFDiRyM307dpi0ddV3dPajTqBkANeqEsnpOXsKbELeVk0ePMPfDNxx17fZc0k+eAPKW6Z5eohpQJ4x9W/8sNJ7m3Xqfc4/saTlZWayeM51jifvB2Eg7kcKxxP2ORDa0WauzkliAiDZ/LdmNaN2e9Yt+JjMtlcP79uBZ2YfqgcGFj014A1bO/J49WzZRrWZtPCtVdpSlHEkiOekgS7/77K9rzskhOelQsbPNbu4eXPvgExzZv5dDu3cQt2YlW1cup//I0RibjT+XL2J/bAyW3U5mejqu7m5FtucbUAsfP3/2x8UQEBLGvq2baX9t0ffbFiftRApePj4lqtv+ukH8MWsqM96cgE81PwLDG2BzcQEgftNaqgeF0Pfeh8nKzGD+pHfZHbSR0KYtijwP8mZpD+/bU1i3IiIi/zhKZEVELqEZ6xOYOD+WA8nptKl0imttW3Hz9KJWvQgAaoZFkLgjlkO74+nQ/2bHeWcubzXG5lhiamER1KAxXW8Zek5fyUkH/3aewW4/v/tVT4uePwsvHx8G3DQGm4sL8z59h9zsHEf535PYvx9zdXcnvGUUcdGrOBi/nUZXdCmyP2MMYc1a8fu0b+l80x3nlHt6V2bgI2Mv6FqMMdQIqUuNkLo0uqIr340fy/FDiSQfSuTQ7nj6jXgMNw9PNi6ZT8rhpGLba3xlV7atXE7yoYPUbdICd0+vC4rrNBdXV3Kys3Hz8Cy2rldlH7rddqfj9bxP38G3Rl4yv3XFMrreOhxjs+Hh5U2dRs04GL+d0KYtijwPIDcnG1e3opN4ERGRfxJt9iQiconMWJ/A2GmbSUhOxwLWp3qTefI4W9ZGU7te3jLiWmERxKz8FXdPL3z8qhfbZlD9RiTExXD8UKLj2KWYSctKT6NS1WrYXFw4fvAAh3btPO82Gl3RhZjfl3AkYS+hZ8w2FyayfSeade1FcIPGZx2v6h+Aq7s7O9atdhxLTjpIVkY6AG4eno6v/y456SDHDx5wvE45cojc3BwqVfUlKz0ND+9KjvN3bogu0XWFRDYh5cghtvy2uMhlyCVVrVYgKUeKT6ABMlJPOTa2SojbSkrSIcJatAGgcrXqJMTFAHmJaeKOOKrVql3seQDJSYcc9w6LiIg4A83IiohcIhPnx5Ke/deMaC4uJOBLtbRMvKv4AlAjuC5pKSmENmtVojar+gfQ9ZZh/Db1G3Kys7Hn5lCzbj3HpkqlpWWPq/n1+y/ZuWENPn7+1AoLP+82fPz8qVqjJjVCQovcQOm0SlV9ad619znHbS4u9Bp2P3/M+pHNyxZi2e14Va5C99vvAqBp5x78/PFbuLq5nbPZU052Nn/MmkpG6ilcXF3z7ou9ZRhelX2IaNOePVs3M+1/4/Gu6kut0PAS7ZZsbDYiWrdnf2zMWculY1b+SmZqGq169eVU8nEWffWR45E9y3/4itBmrQlp2OSc9kKbtCQhbqtjM6/EnXH8OuVLsjMzANi5fg1dbh5CYEQkSXt3sXr2NIzNhmelyvQePsIxk9qh/yBWTJ9M/IZo7HY7QfUbUj/qCoAiz7Msi8T4OFr3vqbYaxcREfmnMP/U7fajoqKs6OiSfTouIvJPFDZmDgW9wxpg14Sye1ZrecnKSOfH116g/8jRVKparbzDKVXzPnmbyHYdS+XZq5npacz98A2ue2h0uSzv3bftT3ZvXk/nm4aUed8iIlI0Y8xay7Kiiq95+dGMrIjIJRLo60VC8rlLXgN9L+6eSmewbdVyNiyeT9POPStUEntk/x6WfPsZ1QODS7RcuiQ8vLxpe81ATh0/ekGPSrpY2ZmZtLl6QJn3KyIicjF0j6yIyCUyuk8kXm4uZx3zcnNhdJ/Icoqo7DTs0JlbnxlPsy49yzuUUuUfXJebnnqeHnfcg7GV3q/Q4AaNyyWJBajXog3ePlUuaR+Tb27LNwNbOO7TBYibO5lPutRmy4+TLqjNb29sTfKe7Wcdm3ZXLw5u+uO8zp31UH/2/bH4gmIoSfuTb2573udvnfklU4d04Yc7OvPD7Z3Y+PXblOUKul/GDudI3GYA9q1axIx7+zCpRx1Wf/DiWfVSjxxk/pihTLuzJ1OHdGHnwuklKov+eAJfD2jGtLt6Me2uXqx481+OsoX/dw9JMesu8RWKSEWgGVkRkUtkYKu8zXNO71oc6OvF6D6RjuMilxPv6gEkrF5KyBV5H27Ezfse/8jmBda17HYw5qKez+us4uZOJmb65/R9bTKVAgLJOHGcBc8MB6DFHaMuef8HN6/Gys3Bv0He47+qBIXR+anX2Llo5jl1V739LDWbRtFywpekHTvMzHuvplbLK6jkX6vIMoAGfW+l3Yhx57TZ4vaRrPngRa5544dLe6Ei4vSUyIqIXEIDWwUpcRUB6ve9hbh5Uwi5oicnD+wlNyOdamENHeVrJ/2XEwm7yElP5UTCHq59ZzoePr4X3F/a0SR+++9TnEzcC0CLwQ8RcdWNRZ6zff4PxEz7DHtO3qZf7Uf+m8BWVwJ5s6yR/W5j/+qlpB9LovngkTQeOAyAxA0rWPH6OFw9vQho0gbOmD319M3bjTw7PY2l40eSsncHxsUVv3oN6f7se+fEsHbSRLqMeZ1KAYF551epRsfHJvDTg9fS7NYRnDy4n9kjBxDe63oObVpNTlYmHZ+YQK1m7UiIXkb0J68w4IM5AGe9Pr47jmUTHiM3MwPLnktkv8E0vfm+c/qP/elrwntd73hdNaQeALuWzj5rRh3g2I4YWtyel1x7+9WgWr2G7Foyi6Y33VtkWVFqNGzJqaQDnDiwhyqBpbuJnYhULEpkRURE5JILbNWRrTM+J/NkMnHzphDR5yaOxG48q87Bjau4/pNfHMlfcRaMuwuXM55fnLL3r8dErXh9LP4NmnHVy5+TejiRGff2oXqDZlQLbVBoeyEdelK/z00AHN8dy7wnB3Pb1LWO8tysLAZ8MIcTB/Yw7c4eNOh7M2BY/PwD9PzPR9Rq3p4dC6axZeonjnMGfjQPyFuim5ORxqCvlgGQeTL5nP4zT6aQmnSAgMZtzjruF94IgBMJuzEurqQfO4x/ZAs6jPw3CWuXs+TfD3DL5FVFjlXMtM+o26kPLe94uND+IS8pbznssSLbOs0/sjk7F82gev2mnDywh8Mx6/CtG1FsGcCOBT+yb9UivKsH0Obupwho/NfGaQFNWnNg3W9KZEWkSEpkRUREpNTNWJ/gWFb/cEoGi7clUa97f3Yumkn84plc9+5P5ySyIR16ljiJBej94iR869Z3vJ52Vy/H1wlrl3PlYy8DUKlGbYLbdSdxw8oiE9kT+3ex5N8PkHb0EMbFlbQjB8lIPuqIKbxn3qZYVQLr4uZVmdTDB8lOPYl75SrUat4egIjeN/D7f586p+3qEU04vjuOFW+Mo3bLKwjp0KOACEp2H6yLh6dj1jSoTWeMzYWU/fFFnlOrRQeiP3qJ3MwMarfqSO38mea/Sz1yEC+/GiWKo8Oo/7Dq7WeZflcvKtcKoXbrjthc3Iota3zDXbS+80lsrq7s+2Mxv4wdxk1fL3fMwHv5BZCalFhovyIioM2eREREpJTNWJ/A2GmbSUhOxwJy7RZvLNrO7jpdWffpq1QLa4hnVb9zznPzqlS6gfztHtvibrld/Pz9NBl0Dzd+sZSBH8/H2FzIzcp0lJ85+2tcXLBycygo+bQKOFY1pB6DvlpGYOuO7F+9hOl3X0VudtZZdTx8fKkUEEhSzNqzjh/buRWAKkGhZ1zLmRdjAQbj4gp2u+PombGH9xzAtW9Px6d2HTZ89SbLXn60wDFwcfcgNyujwLK/86rmT/dn3+OGzxZx1cufk516Et/Q+sWWeVcPwJb/bOmQ9j3w9gvg+O64s+J29fAsUQwicvlSIisiIiKlauL8WNKzz76fMjPbzv/WphJ17xhalXDp6sUIatOZ2FlfAXmzjPtXL6V2y4JnIU/LSj2JT+06AGyb9bXjXtmi+IZGkp16kkOb1wCwc9EMctLTzql36lACNpuN0C7X0GHUC6QdOUjWqRPn1Gs9/AlWvfM8qUkHAMg4cZzfXx9DyzsexuaaN6OZm5nBzkUzADiw7ncsu52qwWFUCazDiYTdZJ06gWW3O+oApOyLx9u/Fg2uuZVWwx7l8Nb1BV6PX71GZy3RLkpGyjHsOTkA7F+9lOS9O6jXY0CxZamH/5ptPRK7kdTDiY57cQGS92zHL6JxiWIQkcuXlhaLiIhIqTpQwPOTTx9v2H9Iidv59eVHqdftOsdOx+fjysde5reJo/lxeN4S3vYPPnvWMuSCdBj1H+Y/PYRKAbUJbNUR98rFP5bI1cOT7s+9x2//fQpXTy8CozrjXaP2OfWO7Ywh+uMJAFj2XFrd+SRe1fzPqRd57WBys7OY+/gteXVzc6nf92bHxkkAXn41OB6/jZlT+pKTlUn3597H5upG5ZrBNL7xbqbf3Ruf2nXwj2zBiYTdAMQvnsHORTNxcXN3XGtBQrtcw/7VSx1LpQ+sX8HS8SPJTj0J5N3b2vWZNwlq05mkLWtZ9fZzGBcbXr7+XPXKV46Z1KLKVr//Asd2xmBsLri4udPt/97ByzdvLLLTUknZu6PYDx1ERExZPpfsfERFRVnR0dHlHYaIiIicp44TFpNQQDIb5OvF72MKujdUSipl/y5mjxzA7TM2XZL2M0+mMHvU9Qz4cG65LO+NmfYZGSnHaH3nE2Xet8g/kTFmrWVZUeUdxz+RlhaLiIhIqRrdJxIvN5ezjnm5uTC6T2Q5RSQl5eFTlfYP/h+nDu4rl/5tbm40H/xgufQtIs5FM7IiIiJS6s7ctTjQ14vRfSL1TGURkfOkGdnC6R5ZERERKXUDWwUpcRURkUtGS4tFRERERETEqSiRFREREREREaeiRFZEREREREScihJZERERERERcSpKZEVERERERMSpKJEVERERERERp6JEVkRERERERJyKElkRERERERFxKkpkRURERERExKkokRURERERERGnokRWREREREREnIoSWREREREREXEqSmRFRERERETEqSiRFREREREREaeiRFZEREREREScihJZERERERERcSpKZEVERERERMSpKJEVERERERERp6JEVkRERERERJyKElkRERERERFxKkpkRURERERExKkokRURERERERGnokRWREREREREnIoSWREREREREXEqSmRFRERERETEqSiRFREREREREaeiRFZEREREREScihJZERERERERcSpKZEVERERERMSpKJEVERERERERp6JEVkRERERERJyKa3kHICJS1kYM/BQ3Dxfc3f96C3z6lesICKx6wW3e2OF1vl78EF7e7ox/bDr3PNGdWsG+JapflMWzt/DZG78SULsKOdm5BIX68cDY3vhU9Sz0nNSTGSyYsZmBQ9o6jr334gK69WtE45bB539xZ8TSsHkggXWqFVlv/ardfP3ubwAkH03Fbln4+VcG4Oa7O7B62U7CG9XkmptaXnAsAJkZ2fzfiO/5z/s34+nlxsxvolk4808S9x1nzMQBRHWq56gb92cin73xKxnp2bi5uzDi6Z7Ua1iz2DK73WLKxyv5fWEsbu6u+Nf0Ydz/BgLw7AM/8ND/XUXNi/i5ERERkQujRFZELkujX7qWOuH+l6Ttf71+fam217xtCKNfvg673eK1cbOZ+tkf3Plo10Lrp57MZMbX0Wclsg+O633RcSydE0MVX69iE9lWHUJp1SEUgCkfryQjPZthD3dxlK9etvOiYwGY+/0GOnSvj6eXGwBNWgXTrksE77+04Kx6lmUxcewsHv3PNTRpFczWDQm88dw83pw8FKDQMmMMsyevI2HvMd74biiuri4kH011tNvv1lZ8/8lKRj17dalcj4iIiJScElkRkTPc2OF1Bo/oyB+/7uBkSjpDR3bhih71AVi5eDvffvg7Hh6uXNGjAd9+8HuBs6ojBn7KM68NoE64P99/spLlC2Jxd3fFGPj3u4Oo5JM3mzr3+w0F9lMYm83QrE0d1q7YBcAXby1jy/r95GTnUsXXiwfHXUVA7Sp8/N8lpJ7K5IkhX+Ph6cpLH9/Ksw/8QP/b2xDVqR5pqZl8/sYy9uw8TFZmLk3bBDP8ka64uNh49oEfCG9ck7jNiRw7coorezZgyEOdWTx7Czu3HeLT/y3huw9XMHRUZ1q0q3vB47wv/gjPPTSVI4dOEtmsNqOe7YMxpsjY/m7BzM08/84gx+uIxrUK7OtEcjqpJzNp0ipvNrpRyyCOHT5FfGwS/jV9Ci0Lb1iTWd+t5YUPbsbV1QUA3+qVHO226RjGBxMWkp6ahVelomfWRUREpHQpkRWRy9LEZ2Y7lha7uBhe/fx2R5lXJXde/Www2zYm8Nq/5nBFj/qkHEvjgwkLefmTWwmsU41Z360rto9TJzKY+e1aJs0dgYenK+mpWbh7/PW2W1A/RcnOymHNbzsJz1/2ev3Qto6ZzoUzN/P1u8t5fHw/7n2yO0/d+S2vfXVHge18/sYyGrcO4sFxvbHbLd547mcWz9pC74HNADhy8CQvfHAz6WlZPHTjJHpe15Qe1zZh6ZwYRzJ8sfbuPMpzb9+IsRmeHPo1m1bvpUX7usXGdtqRQyfJTM8moHaVYvuqWs0bH18vVi/bSbsu4axZvpP0tCwOJ54gvGHNQstqh/hyIjmDFYviWL10J8ZmuH5oW9p1CQfA1dWFOvX82bbpAK2uCL3oMREREZGSUyIrIpelopYWd+odCUD9prU5djiVrMwc4v5MpF5kgGNZbY/rmvD5m78W2YdXJXeC6lTjzed/plWHUKI6hZ01c1dQP2cmuqdtWrOPJ4Z8DUDD5oHcMKwdAOtW7mLe1I1kpGeTm2sv8bWv+W0n22MOMuvbvGQ8MyOb6gGVHeVX9qyPzWaoVNmD4FA/DiWkFLuc+Hy16xruuNZ6kQEcTEimBXWLje20o0knqernXeL+np5wHV++s5zvP1lFg6a1CA7zw8XVVmRZbo6dnOxcLDtMmHQbifuS+df9U6hTr7rj/mff6t4cTTp5scMhIiIi50mJrIhcFmasT2Di/FgOJKfTIiWdRVuTuLOQRNbNPW8Z6enlrLm5dizAmPPr08XFxsuf3Ma2TQfYvHYvo4d/y79ev57Q+jUK7acgp++RPVNS4gk+f+NXXvlsMDUDq7Jt0wHeePbnkgVmwdOvXketoII3o3I7YxMsm812XklySZ3bh1Wi2E5z93AlOyu3xP3Va1jTsQw5OzuXu6/5kODQ6kWW+VT1wtPbjS5XNwSgdogvYZEB7IpLciSy2Zm5BX74ICIiIpeWHr8jIhXejPUJjJ22mYTkdCwgx27x5qI4ZqxPKHEbDZrUYue2JBL3JQOwZM6WYs9JT83iRHIaTVoHc+u9V1KnXnX2xR+90Ms4p21XNxd8/Spht1v8Mn2To8yrkgeZGTnk5hScgEZ1rsf0L9c4EtQTyekcOpBSbJ9eldxJO5XpeH006RSjbvn84i7kAmMLrOPH8SOpZGfllKjd42ds0jT9i9U0bhVM7RDfYss69Y5k/ardAKQcS2PPjsOE1PvrA5D9u485PpgQERGRsnNRHyMbY/yAKUAosBu42bKs44XUrQJsBaZbljXyYvoVETkfE+fHkp599uxd0Ib9TNqSyPKaPgA88EwvIhoVvFkQ5G3yc//TPXnpiRn4VPUkqnM9XF1teHi6FXpOWmomE8fMJjMzB8uyqBcZQPtuEaVyTXUj/LmiR30eHfwFNWpWoXHrIGLyE3Ofqp506dOQx27/ispVPHjp41vPOveuR7vx5TvLeWLI1xgDbm4u3Plot2IfI9N7YDO+eHsZP327liEjO1OpskeBmzBdjJLG5uHpStM2wfy5br9jh+QZX0czZ8p6TiSn884L83Fzd+XNyUPxruTBgumbWP5LLHa7nfCGNXlo3FWOtooqu/2BTrzzwnzmfr8BY2DwiI4Eh/oBebPiwCXb/VpEREQKZyzLuvCTjXkVOGZZ1gRjzBigmmVZTxdS902gRn79YhPZqKgoKzo6+oJjExE5LWzMHAp6pzPArgn9StzOmbvTLp69hUU//cmLH91SOkE6oZ++XUvVat507duoXPrftukAM76OZsyr/cul/6/f+41awb706t+0XPoXEZGKzxiz1rKsqPKO45/oYm/sGQB0y//6C2ApcE4ia4xpA9QE5gH6RohImQr09SIhOb3A4+djzvfrWbl4O7m5dipX8eSBsb1KK0Sn1H9wm3Ltv2HzQKI6hpGRnu14lmxZ8vOvRI9rm5R5vyIiInLxM7LJlmX5nvH6uGVZ1f5WxwYsBoYAPYEozciKSFk6fY/smcuLvdxcePmGZgxsFVSOkYmIiIgUTjOyhSt2RtYYsxAo6MaxcSXs40FgrmVZ+0wxW34aY+4D7gOoU6dOCZsXESna6WT19K7Fgb5ejO4TqSRWRERExEld7IxsLNDNsqxEY0xtYKllWZF/q/MN0BmwA5UBd+A9y7LGFNW2ZmRFRERERORyphnZwl3sPbI/AcOACfn/zvx7Bcuybj/9tTFmOHlLi4tMYkVEREREREQKc7HPTZgA9DbGbAd657/GGBNljPnkYoMTERERERER+buLWlp8KWlpsYiIiIiIXM60tLhwpfskexEREREREZFLTImsiIiIiIiIOBUlsiIiIiIiIuJUlMiKiIiIiIiIU1EiKyIiIiIiIk5FiayIiIiIiIg4FSWyIiIiIiIi4lRcyzsAERHJM/GV9ri6eeDq6uE4dseQSVSrFuJ4vWTJm/y5eTYAx47uplIlfzw8KwMwZOjn+PoGFdi23W5nyeLX6db9EVxc8t76v58yirqhbWnffugFx3z0yC7eeL0bATUbOI5VrlyDO+/6tsjzoqMnExbanur+YRfc92lvv9UbgNycLI4d20ONgPoAhIS0ZuD1r1x0++dre9yvuLi6Ua/elYXW+f23j3B18yx27L/95l4aNuxF6za3FFj++aTb6dvvWWrWjGRrzC8sWvQaSYdi6dptFD17PeGol5ycwMzpYzhxIhG7PZeevZ+kadN+AKSkHGBmUf5/AAAR9ElEQVTaj09y6mQSubnZNGjQnauveRabzcYv818mZss8bC5uuLp6cHXfcY7r+vKLYfTqPZrAwKbnO0QiIiIXTYmsiMg/yODBH1GzVsNCy7t3f4Tu3R8B4JOPBtGp8/00bNS72HYty87iRf+jS9eHHIlsafH2rsaohxec1znroidTxadmgYmsZVlYlh2bzaVEbZ3u+3DSDiZ9est5x/JXnxY2218LlXJzcy5orHbs+BV390qFJrK5uTl07HTfebf7dzt3LMfd3ZuaNSMB8K9Rj0GDXmft2inn1J310zgi6nemY6f7OHHiIO+924+w0A5UqlydRQv/R506bejZ6wlycjJ5791+bI9bQmTDntQNbU/3Ho/h5ubJ3r1r+fLzoTzzr03YbC506foQC355hWHDv7roaxERETlfSmRFRC4Ds356BoAP3rsWjOG++6cDcDBxK598PIiU5ERCw9pxw43/wxhDRsYJ5sx+jkOH4sjJySQivJNjlq6k1kZPIXrNN9xz3zSMMUz65BZatLoBgMTELcz6aRzuHpXo1+95jh7bQ8yWn/HyrErS4e3cdNObxMYu5s/Ns8m1Z+Pm6snA61+hVu3G533tf/zxJWujp2C351DJ248B17+Cn18dVq74jJ07l+Pq6sGRwzu5bfCHTJ78IJGRPdizezVe3r4Mvv1jtvw5l+XL3ic3Nxs3N0+u7T+ewMCmHEyMYdq00eTmZGK37LRvP5SgoOasXzcVY2zExMyjTZtbCQ/vyJdfDKV5i+vZvXsV7drdwcGDW3F3r0TPXk+wf98G5sx5juzsDHJzsrjiyrto135Isde1ZvU3NG850PG6Ro0IgAI/ADiYGEOfq8cBUKVKLWr412PLlrm0az8EYwyZGSexLIvs7Azsudn4VKkJQGRkD0cbQUHNycpKIzPzFF5eVQkNbccPh+JISUmkatXa5/19ERERuRhKZEVE/kG+/fY+x9Jim82Vh0b+XCrtXtf/Jdas/oYRD87Gzc3TcTwpKc6xDPjtt3qzK34F9cI7MnvWs9Sv340bB72O3W5nyuQHWL/uB9pEnbvENS3tuGN5L0Ddum3pP+Al2kTdwq5dK1nwyyu4urrjU6UmbdsOBmD92u/p1v0RGkR2B+DosT3s2b2aUY8sdCylruwTQJeuDwIQF7uEn2Y+w30jZpzXdcfFLiF+x2/cP2IGLi5ubN48i5kzxjiuefeuPxj1yAKqVg10nHPkSDx33j0Fm83GoYPbWPH7J9x1z/e4u3uxf98Gpnz3AI89sZwVKz6lRYsBjtnV9PRkvLx8adV6kCNJBTh0cBvJyQnUDW1Ln6vHAvDz3P84+vOvUY977p2Ki4sbGRknePftq6nfoNtZS8oLEr9rJX37PVuicQgMas6mjTPo1Xs0hw/vICFhEyF1WgPQu/dTfPP13Ux4qRWZmSfp0nVkgcuF16z+hpCQVnh5VXUcCw5pya74FbRsdWOJ4hARESktSmRFRMrRjPUJTJwfy4HkdG6wZdDmqokM7talzPpv3PhqR+IcWLspR4/toV54R7ZtXcCBA3+ybNm7AGRnpePnF1pgG0UtLe4/4CXefedqsCweLCYpDw1tf1bytm/fOpb9+i7p6SkYDMeP7z3v69u69Rf27VvPe+9eA+QtIbbnZjvK64VfeVYSC9Cy5Q2OmefY2MUcORLPhx/0d5RnZJ4iMzOVsLAOLF70BunpJwiP6ERYWIdC4/D2rkbDhr0KLMvIOMmMaU9xKCkOm82F1NSjHDq4rchENjc3m9RTR6hcuUbxgwBc1388c2c/z9tv9sKveihh9a7EZnMDYMOGaYSGXcF9I2aSnp7MpE9vJSi4xVmzsXGxS1i+7H3uuW/qWe36VA4gJSWxRDGIiIiUJiWyIiLlZMb6BMZO20x6di4AOXaLNxfG4V01nIGtCt60qbS5uv21sZSxuWC35wB5Cd/QYV8UunlUSZ08cYjsrPS85auZp/DwqFxoXXePSo6vs7PTmfLdA9x7/3QCA5uSnJzAaxOvAGDNmm9ZtfIzALp2G0nz5gOKiMCiwxV3OmZ2z+nTvdK5xzzOPGbRuElfBgx8+Zx6rVrfRFi9K9mxfRmLFvwX/xrhhW4uVVA/p82b+wL+NSK4+dZ3sdlc+PD9/uTkZBZxTXmz9S4ubuTkZOLi4lZkXchbTnzr4A8crz/+8AYC8jfFWrliEsOGf4UxBm/vakRG9mRX/EpHIhu/83dmzniaocO/Oie5zs7JPGuGX0REpKzo8TsiIuVk4vxYRxJ7WkaOnYnzY0u9LxcXV9zcvMjMOFmi+o0a9ebXpe9gt+fFl3rqKMeOnd+MaE5OJpO/e4Br+j1Ht+6PMGXyQ472PDx8yMg8Uei52dkZ2O12fPNnS/9Y9YWjrG3bwYx6eAGjHl5QTBILDRtdxdro7zh18jCQt9HSgQN/lvgaGkT2ICZmHkeOxAN5Cf7+fRuAvCXIVasGEtX2Nrp2G8n+/Rv+uraMwq/t79IzTuDrG4TN5sL+fRvYv39jsecYYwgIaMDhwztL1Edq6jHH2G/buoCUlEQaN+kLQDW/EOLilgB5474rfoVjA6ndu/5g6g+PcsfQzxzHznT48PYLum9ZRETkYmlGVkSknBxITj/nWGc+wJ7sxttvVQHg+hv+S3BwC774bAg9ez9JcHCLItv8cepjNG16LZENe55T1qnz/Xz80Q24unk6NnsqzLX9xzPv5xd4+63eGAyurh70u+7f+PnVOafu3++RPX1v79w5/yE4pBVNm10LQHz8ChYt/C+9r3qatu3vYP7P4/l16Tv06/f8OW16e1ejR89HefedvvhWC6Z+/a5FxluYyMgenDxxiM8+GwyWRa49h1atbizxI2Nq1WrEwIGv8P3kkeTmZpGbm01ERBeCQ1qyft0PxGyZh4uLG8bmwjXX5N2v2qzZdXz33Qjefqu3Y7OnovTs9QTTpj7OmtXf4O8fRp26USWKrXGTvmzfvtTxM7E9binTfnyCjIyTGGOIXvMtt9z2PqGh7di1ayW/zHsJY2z4VKnJ0OFf4urqDkD/AS/z04yxrFv3A/bcbBpE9qBFy7xNuWZMf4qc3Cym/vCoo9/Bt39M9eqhpKcnk5KcQN26bUsUr4iISGkylmWVdwwFioqKsqKjo8s7DBGRS6bjhMUkFJDMBvl68fuYHgWcIfKX1NRjTPr0Fh58aG6JlheXtt+Wf4DdnkuXrg+Ved8iIpcLY8xay7JK9gnnZUZLi0VEysnoPpF4uZ39qBQvNxdG9zl3CafI31Wq5Efvq54m+fj+cunfzd2bKzveUy59i4iIaGmxiEg5Ob2h0+ldiwN9vRjdJ7LMNnoS51fYTshloX37oeXWt4iIiBJZEZFyNLBVkBJXERERkfOkpcUiIiIiIiLiVJTIioiIiIiIiFNRIisiIiIiIiJORYmsiIiIiIiIOBUlsiIiIiIiIuJUlMiKiIiIiIiIU1EiKyIiIiIiIk5FiayIiIiIiIg4FSWyIiIiIiIi4lSUyIqIiIiIiIhTUSIrIiIiIiIiTkWJrIiIiIiIiDgVJbIiIiIiIiLiVJTIioiIiIiIiFNRIisiIiIiIiJORYmsiIiIiIiIOBUlsiIiIiIiIuJUlMiKiIiIiIiIU1EiKyIiIiIiIk5FiayIiIiIiIg4FSWyIiIiIiIi4lSUyIqIiIiIiIhTUSIrIiIiIiIiTkWJrIiIiIiIiDgVJbIiIiIiIiLiVJTIioiIiIiIiFNRIisiIiIiIiJORYmsiIiIiIiIOBUlsiIiIiIiIuJUlMiKiIiIiIiIU1EiKyIiIiIiIk5FiayIiIiIiIg4FSWyIiIiIiIi4lSUyIqIiIiIiIhTMZZllXcMBTLGHAb2FFPNHzhSBuHI2TTuZU9jXj407mVPY14+NO7lQ+Ne9jTm5UPjfuHqWpZVo7yD+Cf6xyayJWGMibYsK6q847jcaNzLnsa8fGjcy57GvHxo3MuHxr3saczLh8ZdLgUtLRYRERERERGnokRWREREREREnIqzJ7IflXcAlymNe9nTmJcPjXvZ05iXD417+dC4lz2NefnQuEupc+p7ZEVEREREROTy4+wzsiIiIiIiInKZcapE1hhzkzFmizHGbowpdOczY8zVxphYY8wOY8yYsoyxIjLG+BljFhhjtuf/W62Qeq/mf3+2GmPeMsaYso61ojiPMa9jjPklf8xjjDGhZRtpxVLScc+vW8UYk2CMeacsY6xoSjLmxpiWxpiV+e8vm4wxt5RHrBVBcb8fjTEexpgp+eV/6D3l4pVgzB/Pf//eZIxZZIypWx5xVjQl/VvQGDPIGGMV9XellExJxtwYc3P+z/sWY8y3ZR2jVCxOlcgCfwI3AMsKq2CMcQHeBfoCjYHbjDGNyya8CmsMsMiyrPrAovzXZzHGXAl0BJoDTYG2QNeyDLKCKXbM830JTLQsqxHQDkgqo/gqqpKOO8ALwK9lElXFVpIxTwOGWpbVBLgaeMMY41uGMVYIJfz9eDdw3LKsCOB14JWyjbJiKeGYrweiLMtqDkwFXi3bKCuekv4taIzxAR4G/ijbCCuekoy5MaY+MBbomP9+/miZByoVilMlspZlbbUsK7aYau2AHZZlxVuWlQVMBgZc+ugqtAHAF/lffwEMLKCOBXgC7oAH4AYcKpPoKqZixzz/F4SrZVkLACzLOmVZVlrZhVghleRnHWNMG6Am8EsZxVWRFTvmlmXFWZa1Pf/rA+R9YKOHw5+/kvx+PPP7MRXoqdU1F6XYMbcsa8kZ792rgOAyjrEiKunfgi+Q98FBRlkGV0GVZMzvBd61LOs4gGVZ+vBdLopTJbIlFATsO+P1/vxjcuFqWpaVCJD/b8DfK1iWtRJYAiTm/zffsqytZRplxVLsmAMNgGRjzDRjzHpjzMT8T0TlwhU77sYYG/AaMLqMY6uoSvKz7mCMaUfeB2Y7yyC2iqYkvx8ddSzLygFSgOplEl3FdL5/k9wN/HxJI7o8FDvuxphWQIhlWbPLMrAKrCQ/6w2ABsaY340xq4wxV5dZdFIhuZZ3AH9njFkI1CqgaJxlWTNL0kQBx7Q1czGKGvcSnh8BNOKvT5IXGGO6WJZV6DLwy93Fjjl5//92BloBe4EpwHDg09KIr6IqhXF/EJhrWdY+TVSVTCmM+el2agNfAcMsy7KXRmyXmZL8ftTv0NJV4vE0xtwBRKHbckpDkeOe/4Hk6+T9zpTSUZKfdVegPtCNvL8XlxtjmlqWlXyJY5MK6h+XyFqW1esim9gPhJzxOhg4cJFtVnhFjbsx5pAxprZlWYn5f0gWtBTkemCVZVmn8s/5GehAEfczX+5KYcz3A+sty4rPP2cGeWOuRLYIpTDuVwCdjTEPApUBd2PMKcuytLFcIUphzDHGVAHmAP+yLGvVJQq1oivJ78fTdfYbY1yBqsCxsgmvQirR3yTGmF7kfbDT1bKszDKKrSIrbtx9yNvPY2n+B5K1gJ+MMf0ty4ousygrlpK+v6yyLCsb2GWMiSUvsV1TNiFKRVMRlxavAeobY8KMMe7ArcBP5RyTs/sJGJb/9TCgoJnxvUBXY4yrMcaNvE+UtbT4wpVkzNcA1Ywxp+8V7AHElEFsFVmx425Z1u2WZdWxLCsUeBL4UknsRSl2zPPfy6eTN9Y/lGFsFU1Jfj+e+f0YBCy29MD5i1HsmOcvcf0Q6K97BktNkeNuWVaKZVn+lmWF5r+XryJv/JXEXriSvL/MALoDGGP8yVtqHF+mUUqF4lSJrDHmemPMfvJmROYYY+bnHw80xswFxz09I4H55CVS31uWtaW8Yq4gJgC9jTHbgd75rzHGRBljPsmvM5W8e9Y2AxuBjZZlzSqPYCuIYsfcsqxc8hKpRcaYzeQt6/m4nOKtKErysy7/384dmyAUQ1EAvW8GF3ECR7C0dgbBBWydwQmcwC2srFzBGb6Fv1U/KMiTcyBdivAIhPsS8l1Tar5KskiyrqrzOOa/WW5fz87HqtpV1XKcdkgyq6prkk1e/9zNGxNrvs/jdcdx3Nua7x+aWHe+aGLNT0luVXXJ41+V7TAMt9+smH9QGq0AAAB00upGFgAAAARZAAAAWhFkAQAAaEWQBQAAoBVBFgAAgFYEWQAAAFoRZAEAAGhFkAUAAKCVO4obxHNeqXeDAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 1080x1080 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "idxs = np.random.choice(len(top_movies), 50, replace=False)\n",
+    "idxs = list(range(50))\n",
+    "X = fac0[idxs]\n",
+    "Y = fac2[idxs]\n",
+    "plt.figure(figsize=(15,15))\n",
+    "plt.scatter(X, Y)\n",
+    "for i, x, y in zip(top_movies[idxs], X, Y):\n",
+    "    plt.text(x,y,i, color=np.random.rand(3)*0.7, fontsize=11)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/nbs/dl1/lesson4-tabular-Copy1.ipynb
+++ b/nbs/dl1/lesson4-tabular-Copy1.ipynb
@@ -1,0 +1,332 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Tabular models"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from fastai.tabular import *"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Tabular data should be in a Pandas `DataFrame`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "path = untar_data(URLs.ADULT_SAMPLE)\n",
+    "df = pd.read_csv(path/'adult.csv')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dep_var = 'salary'\n",
+    "cat_names = ['workclass', 'education', 'marital-status', 'occupation', 'relationship', 'race']\n",
+    "cont_names = ['age', 'fnlwgt', 'education-num']\n",
+    "procs = [FillMissing, Categorify, Normalize]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test = TabularList.from_df(df.iloc[800:1000].copy(), path=path, cat_names=cat_names, cont_names=cont_names)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data = (TabularList.from_df(df, path=path, cat_names=cat_names, cont_names=cont_names, procs=procs)\n",
+    "                           .split_by_idx(list(range(800,1000)))\n",
+    "                           .label_from_df(cols=dep_var)\n",
+    "                           .add_test(test)\n",
+    "                           .databunch())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table>  <col width='10%'>  <col width='10%'>  <col width='10%'>  <col width='10%'>  <col width='10%'>  <col width='10%'>  <col width='10%'>  <col width='10%'>  <col width='10%'>  <col width='10%'>  <col width='10%'>  <tr>\n",
+       "    <th>workclass</th>\n",
+       "    <th>education</th>\n",
+       "    <th>marital-status</th>\n",
+       "    <th>occupation</th>\n",
+       "    <th>relationship</th>\n",
+       "    <th>race</th>\n",
+       "    <th>education-num_na</th>\n",
+       "    <th>age</th>\n",
+       "    <th>fnlwgt</th>\n",
+       "    <th>education-num</th>\n",
+       "    <th>target</th>\n",
+       "  </tr>\n",
+       "  <tr>\n",
+       "    <th> Private</th>\n",
+       "    <th> HS-grad</th>\n",
+       "    <th> Never-married</th>\n",
+       "    <th> Sales</th>\n",
+       "    <th> Not-in-family</th>\n",
+       "    <th> White</th>\n",
+       "    <th>False</th>\n",
+       "    <th>-1.2158</th>\n",
+       "    <th>1.1004</th>\n",
+       "    <th>-0.4224</th>\n",
+       "    <th><50k</th>\n",
+       "  </tr>\n",
+       "  <tr>\n",
+       "    <th> ?</th>\n",
+       "    <th> HS-grad</th>\n",
+       "    <th> Widowed</th>\n",
+       "    <th> ?</th>\n",
+       "    <th> Not-in-family</th>\n",
+       "    <th> White</th>\n",
+       "    <th>False</th>\n",
+       "    <th>1.8627</th>\n",
+       "    <th>0.0976</th>\n",
+       "    <th>-0.4224</th>\n",
+       "    <th><50k</th>\n",
+       "  </tr>\n",
+       "  <tr>\n",
+       "    <th> Self-emp-not-inc</th>\n",
+       "    <th> HS-grad</th>\n",
+       "    <th> Never-married</th>\n",
+       "    <th> Craft-repair</th>\n",
+       "    <th> Own-child</th>\n",
+       "    <th> Black</th>\n",
+       "    <th>False</th>\n",
+       "    <th>0.0303</th>\n",
+       "    <th>0.2092</th>\n",
+       "    <th>-0.4224</th>\n",
+       "    <th><50k</th>\n",
+       "  </tr>\n",
+       "  <tr>\n",
+       "    <th> Private</th>\n",
+       "    <th> HS-grad</th>\n",
+       "    <th> Married-civ-spouse</th>\n",
+       "    <th> Protective-serv</th>\n",
+       "    <th> Husband</th>\n",
+       "    <th> White</th>\n",
+       "    <th>False</th>\n",
+       "    <th>1.5695</th>\n",
+       "    <th>-0.5938</th>\n",
+       "    <th>-0.4224</th>\n",
+       "    <th><50k</th>\n",
+       "  </tr>\n",
+       "  <tr>\n",
+       "    <th> Private</th>\n",
+       "    <th> HS-grad</th>\n",
+       "    <th> Married-civ-spouse</th>\n",
+       "    <th> Handlers-cleaners</th>\n",
+       "    <th> Husband</th>\n",
+       "    <th> White</th>\n",
+       "    <th>False</th>\n",
+       "    <th>-0.9959</th>\n",
+       "    <th>-0.0318</th>\n",
+       "    <th>-0.4224</th>\n",
+       "    <th><50k</th>\n",
+       "  </tr>\n",
+       "  <tr>\n",
+       "    <th> Private</th>\n",
+       "    <th> 10th</th>\n",
+       "    <th> Married-civ-spouse</th>\n",
+       "    <th> Farming-fishing</th>\n",
+       "    <th> Wife</th>\n",
+       "    <th> White</th>\n",
+       "    <th>False</th>\n",
+       "    <th>-0.7027</th>\n",
+       "    <th>0.6071</th>\n",
+       "    <th>-1.5958</th>\n",
+       "    <th><50k</th>\n",
+       "  </tr>\n",
+       "  <tr>\n",
+       "    <th> Private</th>\n",
+       "    <th> HS-grad</th>\n",
+       "    <th> Married-civ-spouse</th>\n",
+       "    <th> Machine-op-inspct</th>\n",
+       "    <th> Husband</th>\n",
+       "    <th> White</th>\n",
+       "    <th>False</th>\n",
+       "    <th>0.1036</th>\n",
+       "    <th>-0.0968</th>\n",
+       "    <th>-0.4224</th>\n",
+       "    <th><50k</th>\n",
+       "  </tr>\n",
+       "  <tr>\n",
+       "    <th> Private</th>\n",
+       "    <th> Some-college</th>\n",
+       "    <th> Married-civ-spouse</th>\n",
+       "    <th> Exec-managerial</th>\n",
+       "    <th> Own-child</th>\n",
+       "    <th> White</th>\n",
+       "    <th>False</th>\n",
+       "    <th>-0.7760</th>\n",
+       "    <th>-0.6653</th>\n",
+       "    <th>-0.0312</th>\n",
+       "    <th>>=50k</th>\n",
+       "  </tr>\n",
+       "  <tr>\n",
+       "    <th> State-gov</th>\n",
+       "    <th> Some-college</th>\n",
+       "    <th> Never-married</th>\n",
+       "    <th> Tech-support</th>\n",
+       "    <th> Own-child</th>\n",
+       "    <th> White</th>\n",
+       "    <th>False</th>\n",
+       "    <th>-0.8493</th>\n",
+       "    <th>-1.4959</th>\n",
+       "    <th>-0.0312</th>\n",
+       "    <th><50k</th>\n",
+       "  </tr>\n",
+       "  <tr>\n",
+       "    <th> Private</th>\n",
+       "    <th> 11th</th>\n",
+       "    <th> Never-married</th>\n",
+       "    <th> Machine-op-inspct</th>\n",
+       "    <th> Not-in-family</th>\n",
+       "    <th> White</th>\n",
+       "    <th>False</th>\n",
+       "    <th>-1.0692</th>\n",
+       "    <th>-0.9516</th>\n",
+       "    <th>-1.2046</th>\n",
+       "    <th><50k</th>\n",
+       "  </tr>\n",
+       "</table>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "data.show_batch(rows=10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "learn = tabular_learner(data, layers=[200,100], metrics=accuracy)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "Total time: 00:03 <p><table style='width:300px; margin-bottom:10px'>\n",
+       "  <tr>\n",
+       "    <th>epoch</th>\n",
+       "    <th>train_loss</th>\n",
+       "    <th>valid_loss</th>\n",
+       "    <th>accuracy</th>\n",
+       "  </tr>\n",
+       "  <tr>\n",
+       "    <th>1</th>\n",
+       "    <th>0.354604</th>\n",
+       "    <th>0.378520</th>\n",
+       "    <th>0.820000</th>\n",
+       "  </tr>\n",
+       "</table>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "learn.fit(1, 1e-2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Inference"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "row = df.iloc[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(Category >=50k, tensor(1), tensor([0.4402, 0.5598]))"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "learn.predict(row)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/nbs/dl1/rossman_data_clean.ipynb
+++ b/nbs/dl1/rossman_data_clean.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -44,7 +44,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -53,13 +53,13 @@
        "(1017209, 41088)"
       ]
      },
-     "execution_count": null,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "PATH=Path('data/rossmann/')\n",
+    "PATH=Config.data_path()/'rossmann'\n",
     "table_names = ['train', 'store', 'store_states', 'state_names', 'googletrend', 'weather', 'test']\n",
     "tables = [pd.read_csv(PATH/f'{fname}.csv', low_memory=False) for fname in table_names]\n",
     "train, store, store_states, state_names, googletrend, weather, test = tables\n",
@@ -75,7 +75,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -94,7 +94,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -113,7 +113,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -131,7 +131,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -151,7 +151,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -175,7 +175,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -194,7 +194,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -213,7 +213,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -222,7 +222,7 @@
        "0"
       ]
      },
-     "execution_count": null,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -234,7 +234,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -243,7 +243,7 @@
        "(0, 0)"
       ]
      },
-     "execution_count": null,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -256,7 +256,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -265,7 +265,7 @@
        "(0, 0)"
       ]
      },
-     "execution_count": null,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -278,7 +278,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -287,7 +287,7 @@
        "(0, 0)"
       ]
      },
-     "execution_count": null,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -300,7 +300,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -309,7 +309,7 @@
        "(0, 0)"
       ]
      },
-     "execution_count": null,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -322,7 +322,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -341,7 +341,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -361,7 +361,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -380,7 +380,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -398,17 +398,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "array([24,  3, 19,  9,  0, 16, 17,  7, 15, 22, 11, 13,  2, 23, 12,  4, 10,\n",
-       "        1, 14, 20,  8, 18,  6, 21,  5])"
+       "array([24,  3, 19,  9,  0, 16, 17,  7, 15, 22, 11, 13,  2, 23, 12,  4, 10,  1, 14, 20,  8, 18,  6, 21,  5])"
       ]
      },
-     "execution_count": null,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -429,9 +428,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 35,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Collecting isoweek\n",
+      "  Downloading https://files.pythonhosted.org/packages/c2/d4/fe7e2637975c476734fcbf53776e650a29680194eb0dd21dbdc020ca92de/isoweek-1.3.3-py2.py3-none-any.whl\n",
+      "Installing collected packages: isoweek\n",
+      "Successfully installed isoweek-1.3.3\n"
+     ]
+    }
+   ],
    "source": [
     "# If needed, uncomment:\n",
     "# ! pip install isoweek"
@@ -439,20 +449,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [],
    "source": [
     "from isoweek import Week\n",
     "for df in (joined,joined_test):\n",
     "    df[\"Promo2Since\"] = pd.to_datetime(df.apply(lambda x: Week(\n",
-    "        x.Promo2SinceYear, x.Promo2SinceWeek).monday(), axis=1).astype(pd.datetime))\n",
+    "        x.Promo2SinceYear, x.Promo2SinceWeek).monday(), axis=1))\n",
     "    df[\"Promo2Days\"] = df.Date.subtract(df[\"Promo2Since\"]).dt.days"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -467,7 +477,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -500,7 +510,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -528,7 +538,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -537,7 +547,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -560,7 +570,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -580,7 +590,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -593,7 +603,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -613,7 +623,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -629,7 +639,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 32,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -638,7 +648,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 33,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -659,7 +669,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 34,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -668,7 +678,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 35,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -687,7 +697,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 36,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -697,7 +707,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 37,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -707,7 +717,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 38,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -723,7 +733,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 39,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -733,7 +743,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 40,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -742,7 +752,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 41,
    "metadata": {},
    "outputs": [
     {
@@ -902,7 +912,7 @@
        "4              0.0       4.0  "
       ]
      },
-     "execution_count": null,
+     "execution_count": 41,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -920,7 +930,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 42,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -929,7 +939,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 43,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -938,7 +948,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 44,
    "metadata": {},
    "outputs": [
     {
@@ -951,7 +961,7 @@
        "      dtype='object')"
       ]
      },
-     "execution_count": null,
+     "execution_count": 44,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -962,7 +972,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 45,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -972,7 +982,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 46,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -981,7 +991,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 47,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -997,7 +1007,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 48,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1013,7 +1023,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 49,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1023,7 +1033,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 50,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1044,6 +1054,18 @@
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Solves the issue raised in [this forum post](https://forums.fast.ai/t/rossman-data-clean-ipynb-got-typeerror-dtype-class-datetime-datetime-not-understood/38936) where the `datetime` type conversion throws an error.