### PR TITLE
Fix datetime type conversion in rossmann_data_clean nb

### DIFF
--- a/nbs/dl1/rossman_data_clean.ipynb
+++ b/nbs/dl1/rossman_data_clean.ipynb
@@ -446,7 +446,7 @@
     "from isoweek import Week\n",
     "for df in (joined,joined_test):\n",
     "    df[\"Promo2Since\"] = pd.to_datetime(df.apply(lambda x: Week(\n",
-    "        x.Promo2SinceYear, x.Promo2SinceWeek).monday(), axis=1).astype(pd.datetime))\n",
+    "        x.Promo2SinceYear, x.Promo2SinceWeek).monday(), axis=1))\n",
     "    df[\"Promo2Days\"] = df.Date.subtract(df[\"Promo2Since\"]).dt.days"
    ]
   },


### PR DESCRIPTION
Fixes issue in `rossman_data_clean.ipynb` reported in [this forum thread](https://forums.fast.ai/t/rossman-data-clean-ipynb-got-typeerror-dtype-class-datetime-datetime-not-understood/38936) where type error thrown during `datetime` type conversion.