### PR TITLE
Get path_anno and path_img programmatically in lesson1-pets.ipynb

### DIFF
--- a/nbs/dl1/lesson1-pets.ipynb
+++ b/nbs/dl1/lesson1-pets.ipynb
@@ -147,8 +147,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "path_anno = path/'annotations'\n",
-    "path_img = path/'images'"
+    "path_anno, path_img = sorted(path.ls())"
    ]
   },
   {


### PR DESCRIPTION
This seems safer and neater than hard-coding the two paths.