### PR TITLE
Improve default command for installing libraries

### DIFF
--- a/nbs/dl1/lesson3-planet.ipynb
+++ b/nbs/dl1/lesson3-planet.ipynb
@@ -49,7 +49,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# ! pip install kaggle --upgrade"
+    "# ! {sys.executable} -m pip install kaggle --upgrade"
    ]
   },
   {
@@ -128,7 +128,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# ! conda install -y -c haasad eidl7zip"
+    "# ! conda install --yes --prefix {sys.prefix} -c haasad eidl7zip"
    ]
   },
   {


### PR DESCRIPTION
Installing libraries from python notebooks is actually not easy, but this should work for everybody whose user has access to site-packages.