### PR TITLE
Added a line to download pickled MNIST

### DIFF
--- a/nbs/dl1/lesson5-sgd-mnist.ipynb
+++ b/nbs/dl1/lesson5-sgd-mnist.ipynb
@@ -30,7 +30,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "path = Config().data_path()/'mnist'"
+    "path = Config().data_path()/'mnist'\n",
+    "! wget http://deeplearning.net/data/mnist/mnist.pkl.gz -P {path}"
    ]
   },
   {
@@ -655,6 +656,18 @@
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
In `lesson5-sgd-mnist` this was the only instructions on how to get data:

> Get the 'pickled' MNIST dataset from http://deeplearning.net/data/mnist/mnist.pkl.gz.

So I added a line to actually do that:

    ! wget http://deeplearning.net/data/mnist/mnist.pkl.gz -P {path}



