### PR TITLE
Remind people to disable ads block add-ons

### DIFF
--- a/nbs/dl1/lesson2-download.ipynb
+++ b/nbs/dl1/lesson2-download.ipynb
@@ -75,7 +75,7 @@
     "\n",
     "Press <kbd>Ctrl</kbd><kbd>Shift</kbd><kbd>J</kbd> in Windows/Linux and <kbd>Cmd</kbd><kbd>Opt</kbd><kbd>J</kbd> in Mac, and a small window the javascript 'Console' will appear. That is where you will paste the JavaScript commands.\n",
     "\n",
-    "You will need to get the urls of each of the images. You can do this by running the following commands:\n",
+    "You will need to get the urls of each of the images. Before running the following commands, you may want to disable ads block add-ons (YouBlock) in Chrome. Otherwise window.open() coomand doesn't work. Then you can run the following commands:\n",
     "\n",
     "```javascript\n",
     "urls = Array.from(document.querySelectorAll('.rg_di .rg_meta')).map(el=>JSON.parse(el.textContent).ou);\n",


### PR DESCRIPTION
Just add a single sentence to remind people before running javascript commands to get the URLs, first disable ads block add-ons such as YouBlock.