### PR TITLE
Fixed a bug in Model0

### DIFF
--- a/nbs/dl1/lesson7-human-numbers.ipynb
+++ b/nbs/dl1/lesson7-human-numbers.ipynb
@@ -621,7 +621,7 @@
     "        self.bn = nn.BatchNorm1d(nh)\n",
     "        \n",
     "    def forward(self, x):\n",
-    "        h = self.bn(F.relu(self.i_h(x[:,0])))\n",
+    "        h = self.bn(F.relu(self.h_h(self.i_h(x[:,0]))))\n",
     "        if x.shape[1]>1:\n",
     "            h = h + self.i_h(x[:,1])\n",
     "            h = self.bn(F.relu(self.h_h(h)))\n",


### PR DESCRIPTION
Acc to the Lesson 7 video, Model1 is just the refactored version of Model0, but it is actually not, due to a missing self.hh term. 

This fix incorporates that term to make Model0 and Model1 equivalent.