### PR TITLE
Add missing comma to lesson2-download notebook

### DIFF
--- a/nbs/dl1/lesson2-download.ipynb
+++ b/nbs/dl1/lesson2-download.ipynb
@@ -640,7 +640,7 @@
    "source": [
     "# If the plot is not showing try to give a start and end learning rate",
     "# learn.lr_find(start_lr=1e-5, end_lr=1e-1)",
-    ""
+    "",
     "learn.recorder.plot()"
    ]
   },


### PR DESCRIPTION
Jupyter was refusing to open it for it being "invalid JSON" without this comma.