### PR TITLE
Update 06_cuda_cnn_hooks_init.ipynb

### DIFF
--- a/nbs/dl2/06_cuda_cnn_hooks_init.ipynb
+++ b/nbs/dl2/06_cuda_cnn_hooks_init.ipynb
@@ -264,8 +264,8 @@
    "source": [
     "class CudaCallback(Callback):\n",
     "    def __init__(self,device): self.device=device\n",
-    "    def begin_fit(self): self.model.to(device)\n",
-    "    def begin_batch(self): self.run.xb,self.run.yb = self.xb.to(device),self.yb.to(device)"
+    "    def begin_fit(self): self.model.to(self.device)\n",
+    "    def begin_batch(self): self.run.xb,self.run.yb = self.xb.to(self.device),self.yb.to(self.device)"
    ]
   },
   {


### PR DESCRIPTION
Change CudaCallback to access its instance variable self.device instead of the global variable device.  Not really a big deal since we don't use this version of the callback