### PR TITLE
Fix .std to .var in layer & instance normalization

### DIFF
--- a/nbs/dl2/07_batchnorm.ipynb
+++ b/nbs/dl2/07_batchnorm.ipynb
@@ -498,7 +498,7 @@
     "\n",
     "    def forward(self, x):\n",
     "        m = x.mean((1,2,3), keepdim=True)\n",
-    "        v = x.std ((1,2,3), keepdim=True)\n",
+    "        v = x.var ((1,2,3), keepdim=True)\n",
     "        x = (x-m) / ((v+self.eps).sqrt())\n",
     "        return x*self.mult + self.add"
    ]
@@ -618,7 +618,7 @@
     "\n",
     "    def forward(self, x):\n",
     "        m = x.mean((2,3), keepdim=True)\n",
-    "        v = x.std ((2,3), keepdim=True)\n",
+    "        v = x.var ((2,3), keepdim=True)\n",
     "        res = (x-m) / ((v+self.eps).sqrt())\n",
     "        return res*self.mults + self.adds"
    ]


### PR DESCRIPTION
Mentioned in errata here https://github.com/fastai/course-v3/blob/master/files/dl-2019/notes/notes-2-10.md but not fixed in the notebook?