### PR TITLE
Add several missing `self.` in `CallbackHandler` class

### DIFF
--- a/nbs/dl2/04_callbacks.ipynb
+++ b/nbs/dl2/04_callbacks.ipynb
@@ -289,7 +289,7 @@
     "        return res\n",
     "    \n",
     "    def begin_epoch(self, epoch):\n",
-    "        learn.model.train()\n",
+    "        self.learn.model.train()\n",
     "        self.in_train=True\n",
     "        res = True\n",
     "        for cb in self.cbs: res = res and cb.begin_epoch(epoch)\n",
@@ -328,8 +328,8 @@
     "        return res\n",
     "    \n",
     "    def do_stop(self):\n",
-    "        try:     return learn.stop\n",
-    "        finally: learn.stop = False"
+    "        try:     return self.learn.stop\n",
+    "        finally: self.learn.stop = False"
    ]
   },
   {
@@ -347,7 +347,7 @@
     "    def after_step(self):\n",
     "        self.n_iters += 1\n",
     "        print(self.n_iters)\n",
-    "        if self.n_iters>=10: learn.stop = True\n",
+    "        if self.n_iters>=10: self.learn.stop = True\n",
     "        return True"
    ]
   },


### PR DESCRIPTION
`learn.model.train()` (without `self.`) in method `begin_epoch` in class
`CallbackHandler` only worked because `learn = Learner(*get_model(data), loss_func, data)`
is globally defined.
Fix same problem in method `do_stop` in class `CallbackHandler`
and in method `after_step` in class `TestCallback`.