### PR TITLE
fix (?!?): dropout_mask rescaling

### DIFF
--- a/nbs/dl2/12a_awd_lstm.ipynb
+++ b/nbs/dl2/12a_awd_lstm.ipynb
@@ -582,7 +582,7 @@
    "source": [
     "#export\n",
     "def dropout_mask(x, sz, p):\n",
-    "    return x.new(*sz).bernoulli_(1-p).div_(1-p)"
+    "    return x.new(*sz).bernoulli_(1-p).div_(math.sqrt(1-p))"
    ]
   },
   {

--- a/nbs/dl2/exp/nb_12a.py
+++ b/nbs/dl2/exp/nb_12a.py
@@ -7,7 +7,7 @@
 from exp.nb_12 import *
 
 def dropout_mask(x, sz, p):
-    return x.new(*sz).bernoulli_(1-p).div_(1-p)
+    return x.new(*sz).bernoulli_(1-p).div_(math.sqrt(1-p))
 
 class RNNDropout(nn.Module):
     def __init__(self, p=0.5):


### PR DESCRIPTION
**Update**: Before merging, please review the forum thread below, as I am not sure, if my "fix" is actually correct.

see https://forums.fast.ai/t/dropout-mask-messing-with-standard-deviation-in-lesson-12/51978