### PR TITLE
Update Salamander install process

### DIFF
--- a/docs/start_salamander.md
+++ b/docs/start_salamander.md
@@ -66,7 +66,6 @@ Before you start working it's a good idea ot update the pytorch and fastai libra
 Once you click on 'Terminal' a new window should open with a terminal. Type (or copy and paste):
 
 ```bash
-conda install -c fastai -c pytorch fastai pytorch
 cd course-v3/
 git pull
 ```


### PR DESCRIPTION
Just installed this the other day and found that running 'conda install -c fastai -c pytorch fastai pytorch' will end up causing a module issue in vision.learn.

Not running that command seems to fix the issue.