### PR TITLE
Install pre-compiled OpenCV4 for Swift notebooks with OpenCV

### DIFF
--- a/docs/setup/colab
+++ b/docs/setup/colab
@@ -9,4 +9,11 @@ fi
 
 echo Updating fastai...
 pip install fastai --upgrade > /dev/null
+
+echo Downloading OpenCV4...
+curl -sL https://storage.googleapis.com/opencv4/opencv4.tgz | tar zxf - -C / \
+  && ldconfig /opt/opencv4/lib/ \
+  && rm -f /usr/lib/pkgconfig/opencv4.pc \
+  && ln -s /opt/opencv4/lib/pkgconfig/opencv4.pc /usr/lib/pkgconfig/opencv4.pc
+
 echo Done.

--- a/docs/setup/colab
+++ b/docs/setup/colab
@@ -10,10 +10,4 @@ fi
 echo Updating fastai...
 pip install fastai --upgrade > /dev/null
 
-echo Downloading OpenCV4...
-curl -sL https://storage.googleapis.com/opencv4/opencv4.tgz | tar zxf - -C / \
-  && ldconfig /opt/opencv4/lib/ \
-  && rm -f /usr/lib/pkgconfig/opencv4.pc \
-  && ln -s /opt/opencv4/lib/pkgconfig/opencv4.pc /usr/lib/pkgconfig/opencv4.pc
-
 echo Done.

--- a/nbs/swift/08b_data_block_opencv.ipynb
+++ b/nbs/swift/08b_data_block_opencv.ipynb
@@ -30,6 +30,7 @@
     }
    ],
    "source": [
+    "%system SwiftCV/install/install_colab.sh\n",
     "%install-location $cwd/swift-install\n",
     "%install '.package(path: \"$cwd/FastaiNotebook_07_batchnorm\")' FastaiNotebook_07_batchnorm\n",
     "%install '.package(path: \"$cwd/SwiftCV\")' SwiftCV"

--- a/nbs/swift/08b_data_block_opencv.ipynb
+++ b/nbs/swift/08b_data_block_opencv.ipynb
@@ -30,7 +30,8 @@
     }
    ],
    "source": [
-    "%system SwiftCV/install/install_colab.sh\n",
+    "# Uncomment line below when using Colab (this installs OpenCV4)\n",
+    "# %system SwiftCV/install/install_colab.sh\n",
     "%install-location $cwd/swift-install\n",
     "%install '.package(path: \"$cwd/FastaiNotebook_07_batchnorm\")' FastaiNotebook_07_batchnorm\n",
     "%install '.package(path: \"$cwd/SwiftCV\")' SwiftCV"

--- a/nbs/swift/08c_data_block-lightlyfunctional.ipynb
+++ b/nbs/swift/08c_data_block-lightlyfunctional.ipynb
@@ -30,6 +30,7 @@
     }
    ],
    "source": [
+    "%system SwiftCV/install/install_colab.sh\n",
     "%install-location $cwd/swift-install\n",
     "%install '.package(path: \"$cwd/FastaiNotebook_07_batchnorm\")' FastaiNotebook_07_batchnorm\n",
     "%install '.package(path: \"$cwd/SwiftCV\")' SwiftCV"

--- a/nbs/swift/08c_data_block-lightlyfunctional.ipynb
+++ b/nbs/swift/08c_data_block-lightlyfunctional.ipynb
@@ -30,7 +30,8 @@
     }
    ],
    "source": [
-    "%system SwiftCV/install/install_colab.sh\n",
+    "# Uncomment line below when using Colab (this installs OpenCV4)\n",
+    "# %system SwiftCV/install/install_colab.sh\n",
     "%install-location $cwd/swift-install\n",
     "%install '.package(path: \"$cwd/FastaiNotebook_07_batchnorm\")' FastaiNotebook_07_batchnorm\n",
     "%install '.package(path: \"$cwd/SwiftCV\")' SwiftCV"

--- a/nbs/swift/08c_data_block_generic.ipynb
+++ b/nbs/swift/08c_data_block_generic.ipynb
@@ -30,6 +30,7 @@
     }
    ],
    "source": [
+    "%system SwiftCV/install/install_colab.sh\n",
     "%install-location $cwd/swift-install\n",
     "%install '.package(path: \"$cwd/FastaiNotebook_07_batchnorm\")' FastaiNotebook_07_batchnorm\n",
     "%install '.package(path: \"$cwd/SwiftCV\")' SwiftCV"

--- a/nbs/swift/08c_data_block_generic.ipynb
+++ b/nbs/swift/08c_data_block_generic.ipynb
@@ -30,7 +30,8 @@
     }
    ],
    "source": [
-    "%system SwiftCV/install/install_colab.sh\n",
+    "# Uncomment line below when using Colab (this installs OpenCV4)\n",
+    "# %system SwiftCV/install/install_colab.sh\n",
     "%install-location $cwd/swift-install\n",
     "%install '.package(path: \"$cwd/FastaiNotebook_07_batchnorm\")' FastaiNotebook_07_batchnorm\n",
     "%install '.package(path: \"$cwd/SwiftCV\")' SwiftCV"

--- a/nbs/swift/SwiftCV/install/compile_colab.sh
+++ b/nbs/swift/SwiftCV/install/compile_colab.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Execute this script from Colab notebook, e.g.:
+# !git clone https://github.com/fastai/course-v3
+# !course-v3/nbs/swift/SwiftCV/install/compile_colab.sh
+# Resulting `opencv4.tgz` file will appear in `course-v3/nbs/swift/SwiftCV/install` folder
+
+# Download file using Colab's Files panel or move to storage of your choice, e.g. GCP:
+# from google.colab import auth
+# auth.authenticate_user()
+# !gcloud config set project your_project
+# !gsutil cp course-v3/nbs/swift/SwiftCV/install/opencv4.tgz gs://your_bucket/
+# !gsutil acl set public-read gs://{bucket_name}/opencv4.tgz
+
+INSTALL_DIR=/opt/opencv4/
+SCRIPT_DIR=$(dirname $(readlink -f $0))
+
+mkdir -p $INSTALL_DIR
+pushd $SCRIPT_DIR
+INSTALL_PREFIX=$INSTALL_DIR ./install_cv4.sh
+popd
+
+tar vczf $SCRIPT_DIR/opencv4.tgz $INSTALL_DIR -C /

--- a/nbs/swift/SwiftCV/install/install_colab.sh
+++ b/nbs/swift/SwiftCV/install/install_colab.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+if [[ -d "/opt/opencv4" ]]; then
+  echo Already installed!
+  exit 0
+fi
+
+echo Downloading OpenCV4...
+curl -sL https://storage.googleapis.com/opencv4/opencv4.tgz | tar zxf - -C / \
+  && ldconfig /opt/opencv4/lib/ \
+  && rm -f /usr/lib/pkgconfig/opencv4.pc \
+  && ln -s /opt/opencv4/lib/pkgconfig/opencv4.pc /usr/lib/pkgconfig/opencv4.pc
+

--- a/nbs/swift/SwiftCV/install/install_cv4.sh
+++ b/nbs/swift/SwiftCV/install/install_cv4.sh
@@ -1,7 +1,10 @@
 set -ex
 
 OPENCV_VERSION='4.1.0'
-
+CMAKE_OPTS=""
+if [ ! -z ${INSTALL_PREFIX} ]; then
+  CMAKE_OPTS="-D CMAKE_INSTALL_PREFIX=${INSTALL_PREFIX}"
+fi
 APT_PROGRAM="apt-fast"
 command -v $APT_PROGRAM > /dev/null 2>&1 || {
   echo "Falling back to apt-get as apt-fast is not installed..."
@@ -23,6 +26,7 @@ cd OpenCV
 mkdir build
 cd build
 cmake \
+  ${CMAKE_OPTS} \
   -D BUILD_LIST=core,imgproc,imgcodecs \
   -D CMAKE_BUILD_TYPE=Release \
   -D OPENCV_GENERATE_PKGCONFIG=YES \

--- a/nbs/swift/opencv_integration_example.ipynb
+++ b/nbs/swift/opencv_integration_example.ipynb
@@ -46,7 +46,8 @@
     }
    ],
    "source": [
-    "%system SwiftCV/install/install_colab.sh\n",
+    "# Uncomment line below when using Colab (this installs OpenCV4)\n",
+    "# %system SwiftCV/install/install_colab.sh\n",
     "%install-location $cwd/swift-install\n",
     "%install '.package(path: \"$cwd/SwiftCV\")' SwiftCV\n",
     "%install '.package(path: \"$cwd/FastaiNotebook_08_data_block\")' FastaiNotebook_08_data_block"

--- a/nbs/swift/opencv_integration_example.ipynb
+++ b/nbs/swift/opencv_integration_example.ipynb
@@ -46,6 +46,7 @@
     }
    ],
    "source": [
+    "%system SwiftCV/install/install_colab.sh\n",
     "%install-location $cwd/swift-install\n",
     "%install '.package(path: \"$cwd/SwiftCV\")' SwiftCV\n",
     "%install '.package(path: \"$cwd/FastaiNotebook_08_data_block\")' FastaiNotebook_08_data_block"


### PR DESCRIPTION
This change adds pre-built OpenCV v4 in Colab environment to solve problem with SwiftCV installation in some Swift notebooks:  https://forums.fast.ai/t/opencv-in-swift/44514/26

Details:
1. Added script `compile_colab.sh` to build and package opencv4 (this is for reference)
2. Using this script, `https://storage.googleapis.com/opencv4/opencv4.tgz` is created (using CPU Colab runtime)
3. `colab` script is updated to download & use compiled opencv4 binary

I've tested that SwiftCV notebook works when this binary is installed.

Note: it would be good to upload binary to other location (e.g. `https://course.fast.ai/setup/`) instead of `https://storage.googleapis.com/opencv4/opencv4.tgz` because this is my GCP bucket and I may eventually remove it.

