### PR TITLE
Updating packages and course repo - Update

### DIFF
--- a/docs/update_colab.md
+++ b/docs/update_colab.md
@@ -26,7 +26,6 @@ To update packages and the course repo, create a code cell in your notebook and 
 !curl https://course.fast.ai/setup/colab | bash
 ```
 
-<img alt="" src="/images/colab/07.png" class="screenshot">
 
 Colab terminates your instance after 90 minutes of idle time or after 12 hours of runtime (see [here](https://help.clouderizer.com/running-on-cloud/google-colab/google-colab-faqs)). This script will check if your instance has been terminated and install packages and clone repository again if it has. If it has not (you have been away for less than 90 minutes) the script will just update the packages and repository.
 


### PR DESCRIPTION
The image "/images/colab/07.png" showcasing the url to update Colab repo has been updated to  - 
"!curl https://course.fast.ai/setup/colab | bash"
from-  " !curl https://course-v3.fast.ai/setup/colab_update | bash ".

The image may either be removed or altered containing the new url.