### PR TITLE
GCP tutorial - Change GPU type from p4 to p100

### DIFF
--- a/docs/start_gcp.md
+++ b/docs/start_gcp.md
@@ -125,7 +125,7 @@ gcloud compute instances create $INSTANCE_NAME \
         --image-family=$IMAGE_FAMILY \
         --image-project=deeplearning-platform-release \
         --maintenance-policy=TERMINATE \
-        --accelerator="type=nvidia-tesla-p4,count=1" \
+        --accelerator="type=nvidia-tesla-p100,count=1" \
         --machine-type=$INSTANCE_TYPE \
         --boot-disk-size=200GB \
         --metadata="install-nvidia-driver=True" \


### PR DESCRIPTION
The p4 GPUs are no longer available from GCP, so replaced with the p100