### PR TITLE
Fixed dead link to Layer.swift

### DIFF
--- a/nbs/swift/01a_fastai_layers.ipynb
+++ b/nbs/swift/01a_fastai_layers.ipynb
@@ -124,7 +124,7 @@
    "source": [
     "# Introducing Protocols\n",
     "\n",
-    "Just like PyTorch, the S4TF base library provides a standard layer type.  It is defined in the [TensorFlow/swift-apis](https://github.com/tensorflow/swift-apis/) repository on GitHub in [Layer.swift](https://github.com/tensorflow/swift-apis/blob/master/Sources/DeepLearning/Layer.swift) and it looks like this:\n",
+    "Just like PyTorch, the S4TF base library provides a standard layer type.  It is defined in the [TensorFlow/swift-apis](https://github.com/tensorflow/swift-apis/) repository on GitHub in [Layer.swift](https://github.com/tensorflow/swift-apis/blob/master/Sources/TensorFlow/Layer.swift) and it looks like this:\n",
     "\n",
     "```swift\n",
     "protocol Layer: Differentiable {\n",


### PR DESCRIPTION
I honestly do not know if this should remain a link, as it is prone to changing again. Here is the fix if it still needs to be a link :)