### PR TITLE
Minor fix, update comment

### DIFF
--- a/nbs/dl1/lesson2-download.ipynb
+++ b/nbs/dl1/lesson2-download.ipynb
@@ -802,7 +802,7 @@
     "# the new run of `ImageCleaner`.\n",
     "\n",
     "# db = (ImageList.from_csv(path, 'cleaned.csv', folder='.')\n",
-    "#                    .no_split()\n",
+    "#                    .split_none()\n",
     "#                    .label_from_df()\n",
     "#                    .transform(get_transforms(), size=224)\n",
     "#                    .databunch()\n",


### PR DESCRIPTION
Update comment specifying the use of the deprecated no_split() function, currently split_none() should be used.