### PR TITLE
Clarifying language in GCP tutorial

### DIFF
--- a/docs/start_gcp.md
+++ b/docs/start_gcp.md
@@ -139,7 +139,7 @@ ERROR: (gcloud.compute.instances.create) Could not fetch resource:
 You need to adjust your GPU quotas.
 1. Go to [Google Cloud Quotas Page](https://console.cloud.google.com/iam-admin/quotas).
 2. If you signed up with a free tier account, you first need to upgrade to a paid account; do so by clicking the "Upgrade account" button at the top right of the page. This won't affect your $300 credit.
-3. In filter type, select metric to be GPUs (all regions) and Location as Global.
+3. In the "Metrics" dropdown, select "GPUs (all regions)" and under "Locations" select "Global" (or "All locations").
 4. Click edit quotas and select the quota to edit (GPUs All Regions). Set the new quota limit to 1 or more.
 Your request may require confirmation, which Google claims typically takes two business days to get.
 


### PR DESCRIPTION
This change makes the language clearer based on the dropdowns in GCP:

<img width="1070" alt="Screen Shot 2019-09-16 at 9 38 53 AM" src="https://user-images.githubusercontent.com/994938/64976813-10681b00-d867-11e9-8575-0439638fdf5b.png">
