### PR TITLE
Fix region problem in GCP tutorial

### DIFF
--- a/docs/start_gcp.md
+++ b/docs/start_gcp.md
@@ -115,7 +115,7 @@ If you choose the budget compute option, please replace the values of the parame
 
 ```bash
 export IMAGE_FAMILY="pytorch-latest-gpu" # or "pytorch-latest-cpu" for non-GPU instances
-export ZONE="us-west2-b" # budget: "us-west1-b"
+export ZONE="us-west1-b"
 export INSTANCE_NAME="my-fastai-instance"
 export INSTANCE_TYPE="n1-highmem-8" # budget: "n1-highmem-4"
 


### PR DESCRIPTION
This PR https://github.com/fastai/course-v3/pull/393 by @afederation replaced the P4 GPU with the P100 GPU saying that P4s are no longer available.

This had a side effect, which is that the current config tells people to use us-west2-b:

```bash
export ZONE="us-west2-b" # budget: "us-west1-b"
```

_but_  P100s are not available in us-west2-b:
https://cloud.google.com/compute/docs/gpus/

<img width="839" alt="Screen Shot 2019-09-16 at 12 30 23 PM" src="https://user-images.githubusercontent.com/994938/64987314-c63e6400-d87d-11e9-8b42-67a86eeef6d4.png">

This change therefore changes that line to:
```bash
export ZONE="us-west1-b"
```

to make using the P100 work by requesting it in a region in which it's available.


Bigger picture, I'm just getting started so I'm not sure about what the budget option should be here, but it seems worth noting the P4s _are_ still available in us-west2-c and us-west2-b?

<img width="833" alt="Screen Shot 2019-09-16 at 12 31 27 PM" src="https://user-images.githubusercontent.com/994938/64987415-f71e9900-d87d-11e9-8330-e42570947dfe.png">
