### PR TITLE
Fix wrong dimension in Temporal Activation Regularization in RNNTrainer?

### DIFF
--- a/nbs/dl2/12a_awd_lstm.ipynb
+++ b/nbs/dl2/12a_awd_lstm.ipynb
@@ -1080,7 +1080,7 @@
     "        if self.α != 0.:  self.run.loss += self.α * self.out[-1].float().pow(2).mean()\n",
     "        if self.β != 0.:\n",
     "            h = self.raw_out[-1]\n",
-    "            if len(h)>1: self.run.loss += self.β * (h[:,1:] - h[:,:-1]).float().pow(2).mean()\n",
+    "            if h.size(1)>1: self.run.loss += self.β * (h[:,1:] - h[:,:-1]).float().pow(2).mean()\n",
     "                \n",
     "    def begin_epoch(self):\n",
     "        #Shuffle the texts at the beginning of the epoch\n",


### PR DESCRIPTION
Current:

```python
if len(h) > 1: ... apply TAR
```

However, `len(h)` gives the batch size and not the sequence length.
Should this be changed to the following?

```python
if h.size(1) > 1: ... apply TAR
```