### PR TITLE
Update zone configuration for gcloud setup

### DIFF
--- a/docs/start_gcp.md
+++ b/docs/start_gcp.md
@@ -115,7 +115,7 @@ If you choose the budget compute option, please replace the values of the parame
 
 ```bash
 export IMAGE_FAMILY="pytorch-latest-gpu" # or "pytorch-latest-cpu" for non-GPU instances
-export ZONE="us-west2-b" # budget: "us-west1-b"
+export ZONE="us-west1-b"
 export INSTANCE_NAME="my-fastai-instance"
 export INSTANCE_TYPE="n1-highmem-8" # budget: "n1-highmem-4"
 


### PR DESCRIPTION
The nvidia-tesla-p100 accelerator is not available in the gcloud us-west2-b zone, but is available in the us-west1-b zone (see https://cloud.google.com/compute/docs/gpus/#gpus-list). Not sure when this changed. Therefore, it appears that the us-west1-b zone should work for both regular and budget set-up options.