### PR TITLE
Fix logic in Runner __call__ callback loop

### DIFF
--- a/nbs/dl2/05b_early_stopping.ipynb
+++ b/nbs/dl2/05b_early_stopping.ipynb
@@ -187,7 +187,7 @@
     "\n",
     "    def __call__(self, cb_name):\n",
     "        res = False\n",
-    "        for cb in sorted(self.cbs, key=lambda x: x._order): res = cb(cb_name) and res\n",
+    "        for cb in sorted(self.cbs, key=lambda x: x._order): res = cb(cb_name) or res\n",
     "        return res"
    ]
   },


### PR DESCRIPTION
The logic is at least one callback return true Runner.\_\_call\_\_ will return true. But using "and" the method will always return False.

    for cb in sorted(self.cbs, key=lambda x: x._order): res = cb(cb_name) and res

Change to "or" to fix the problem.

    for cb in sorted(self.cbs, key=lambda x: x._order): res = cb(cb_name) or res