### PR TITLE
Update start_gcp.md

### DIFF
--- a/docs/start_gcp.md
+++ b/docs/start_gcp.md
@@ -115,7 +115,7 @@ If you choose the budget compute option, please replace the values of the parame
 
 ```bash
 export IMAGE_FAMILY="pytorch-latest-gpu" # or "pytorch-latest-cpu" for non-GPU instances
-export ZONE="us-west1-b"
+export ZONE="us-west2-c"
 export INSTANCE_NAME="my-fastai-instance"
 export INSTANCE_TYPE="n1-highmem-8" # budget: "n1-highmem-4"
 


### PR DESCRIPTION
For some reason when I ran this and used the zone:

us-west1-b

I got the following error:

ERROR: (gcloud.compute.instances.create) Could not fetch resource:
 - The resource 'projects/static-protocol-256618/zones/us-west1-b/acceleratorTypes/nvidia-tesla-p4' was not found

So when I changed the zone to:

us-west2-c

It seemed to work ok so for some reason that instance type wasn't available in that zone when I tried today! So thats why suggested the change.