### PR TITLE
nvidia-tesla-p4 -> nvidia-tesla-p100

### DIFF
--- a/docs/start_gcp.md
+++ b/docs/start_gcp.md
@@ -125,7 +125,7 @@ gcloud compute instances create $INSTANCE_NAME \
         --image-family=$IMAGE_FAMILY \
         --image-project=deeplearning-platform-release \
         --maintenance-policy=TERMINATE \
-        --accelerator="type=nvidia-tesla-p4,count=1" \
+        --accelerator="type=nvidia-tesla-p100,count=1" \
         --machine-type=$INSTANCE_TYPE \
         --boot-disk-size=200GB \
         --metadata="install-nvidia-driver=True" \


### PR DESCRIPTION
* nvidia-tesla-p4 no longer exists
* Updating to nvidia-tesla-p100 based on linked blog post in reference
* https://blog.kovalevskyi.com/google-compute-engine-now-has-images-with-pytorch-1-0-0-and-fastai-1-0-2-57c49efd74bb