### PR TITLE
adding def cos_1cycle_anneal function...

### DIFF
--- a/nbs/dl2/05_anneal.ipynb
+++ b/nbs/dl2/05_anneal.ipynb
@@ -286,6 +286,9 @@
     "@annealer\n",
     "def sched_exp(start, end, pos): return start * (end/start) ** pos\n",
     "\n",
+    "def cos_1cycle_anneal(start, high, end):\n",
+    "    return [sched_cos(start, high), sched_cos(high, end)]\n",
+    "\n",
     "#This monkey-patch is there to be able to plot tensors\n",
     "torch.Tensor.ndim = property(lambda x: len(x.shape))"
    ]


### PR DESCRIPTION
which is widely used in various notebooks starting from 08 (datablock) and can be found in the nb_05.py exported file, but is not actually defined in the notebook. It seems it was defined in an additional section of this notebook which was later removed or not commited to master. more details on the forum https://forums.fast.ai/t/notebook-and-notebook-exports-mismatch-caused-headaches