### PR TITLE
add info about webconsole shortcuts

### DIFF
--- a/nbs/dl1/lesson2-download.ipynb
+++ b/nbs/dl1/lesson2-download.ipynb
@@ -73,7 +73,7 @@
    "source": [
     "Now you must run some Javascript code in your browser which will save the URLs of all the images you want for you dataset.\n",
     "\n",
-    "Press <kbd>Ctrl</kbd><kbd>Shift</kbd><kbd>J</kbd> in Windows/Linux and <kbd>Cmd</kbd><kbd>Opt</kbd><kbd>J</kbd> in Mac, and a small window the javascript 'Console' will appear. That is where you will paste the JavaScript commands.\n",
+    "In Google Chrome press <kbd>Ctrl</kbd><kbd>Shift</kbd><kbd>j</kbd> in Windows/Linux and <kbd>Cmd</kbd><kbd>Opt</kbd><kbd>j</kbd> in macOS, and a small window the javascript 'Console' will appear. In Firefox press <kbd>Ctrl</kbd><kbd>Shift</kbd><kbd>k</kbd> on Windows/Linux or <kbd>Cmd</kbd><kbd>Opt</kbd><kbd>k</kbd> on macOS. That is where you will paste the JavaScript commands.\n",
     "\n",
     "You will need to get the urls of each of the images. Before running the following commands, you may want to disable ad blocking extensions (uBlock, AdBlockPlus etc.) in Chrome. Otherwise the window.open() command doesn't work. Then you can run the following commands:\n",
     "\n",
@@ -1407,6 +1407,18 @@
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,

--- a/nbs/dl1/lesson2-download.ipynb
+++ b/nbs/dl1/lesson2-download.ipynb
@@ -73,7 +73,7 @@
    "source": [
     "Now you must run some Javascript code in your browser which will save the URLs of all the images you want for you dataset.\n",
     "\n",
-    "In Google Chrome press <kbd>Ctrl</kbd><kbd>Shift</kbd><kbd>j</kbd> in Windows/Linux and <kbd>Cmd</kbd><kbd>Opt</kbd><kbd>j</kbd> in macOS, and a small window the javascript 'Console' will appear. In Firefox press <kbd>Ctrl</kbd><kbd>Shift</kbd><kbd>k</kbd> on Windows/Linux or <kbd>Cmd</kbd><kbd>Opt</kbd><kbd>k</kbd> on macOS. That is where you will paste the JavaScript commands.\n",
+    "In Google Chrome press <kbd>Ctrl</kbd><kbd>Shift</kbd><kbd>j</kbd> on Windows/Linux and <kbd>Cmd</kbd><kbd>Opt</kbd><kbd>j</kbd> on macOS, and a small window the javascript 'Console' will appear. In Firefox press <kbd>Ctrl</kbd><kbd>Shift</kbd><kbd>k</kbd> on Windows/Linux or <kbd>Cmd</kbd><kbd>Opt</kbd><kbd>k</kbd> on macOS. That is where you will paste the JavaScript commands.\n",
     "\n",
     "You will need to get the urls of each of the images. Before running the following commands, you may want to disable ad blocking extensions (uBlock, AdBlockPlus etc.) in Chrome. Otherwise the window.open() command doesn't work. Then you can run the following commands:\n",
     "\n",
@@ -1407,18 +1407,6 @@
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.7.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
just some minor added info for the lesson 2 download notebook on to open the webconsole. The presented shortcuts are only valid for Google Chrome without mentioning that. I also added the shortcuts for Firefox.