### PR TITLE
Updating cyclegan identity loss

### DIFF
--- a/nbs/dl2/cyclegan.ipynb
+++ b/nbs/dl2/cyclegan.ipynb
@@ -392,7 +392,7 @@
     "    def forward(self, output, target):\n",
     "        fake_A, fake_B, idt_A, idt_B = output\n",
     "        #Generators should return identity on the datasets they try to convert to\n",
-    "        self.id_loss = self.l_idt * (self.l_B * F.l1_loss(idt_A, self.real_B) + self.l_A * F.l1_loss(idt_B, self.real_A))\n",
+    "        self.id_loss = self.l_idt * (self.l_A * F.l1_loss(idt_A, self.real_A) + self.l_B * F.l1_loss(idt_B, self.real_B))\n",
     "        #Generators are trained to trick the discriminators so the following should be ones\n",
     "        self.gen_loss = self.crit(self.cgan.D_A(fake_A), True) + self.crit(self.cgan.D_B(fake_B), True)\n",
     "        #Cycle loss\n",


### PR DESCRIPTION
I think the identity losses were flipped.

The original code has id_loss = ||G(A) - A||
https://github.com/junyanz/pytorch-CycleGAN-and-pix2pix/blob/690470c80bb7021d96c9d3f82e416e633dbb2da3/models/cycle_gan_model.py#L158

The notebook had ||G(A) - B||
