### PR TITLE
Fix URL grab method for new Google images DOM

### DIFF
--- a/nbs/dl1/lesson2-download.ipynb
+++ b/nbs/dl1/lesson2-download.ipynb
@@ -78,7 +78,7 @@
     "You will need to get the urls of each of the images. Before running the following commands, you may want to disable ad blocking extensions (uBlock, AdBlockPlus etc.) in Chrome. Otherwise the window.open() command doesn't work. Then you can run the following commands:\n",
     "\n",
     "```javascript\n",
-    "urls = Array.from(document.querySelectorAll('.rg_di .rg_meta')).map(el=>JSON.parse(el.textContent).ou);\n",
+    "urls=Array.from(document.querySelectorAll('.rg_i')).map(el=> el.hasAttribute('data-src')?el.getAttribute('data-src'):el.getAttribute('data-iurl'));\n",
     "window.open('data:text/csv;charset=utf-8,' + escape(urls.join('\\n')));\n",
     "```"
    ]


### PR DESCRIPTION
The current method doesn't work anymore.