### PR TITLE
Add introductory posts

### DIFF
--- a/files/dl-2019/notes/notes-2-13.md
+++ b/files/dl-2019/notes/notes-2-13.md
@@ -29,6 +29,8 @@ Finally, we looked at different ways of calculating matrix products in Swift, in
 
 - S4TF [notebook tutorials](https://github.com/tensorflow/swift#tutorials-) (rather out of date at the moment)
 - Why [fastai is embracing S4TF](https://www.fast.ai/2019/03/06/fastai-swift/)?
+- [Your first Swift for TensorFlow model](https://rickwierenga.com/blog/s4tf/s4tf-mnist.html) (updated for 0.6)
+- [An introduction to Generative Adversarial Networks in Swift for TensorFlow](https://rickwierenga.com/blog/s4tf/s4tf-gan.html) (updated for 0.6)
 
 ## Edit this page
 


### PR DESCRIPTION
These lectures were my first introduction to Swift for TensorFlow and since taking them in the summer I've learned a lot more about the framework. I would like to do something in return and share two posts that might be helpful to beginners: 

- [Your first Swift for TensorFlow model](https://rickwierenga.com/blog/s4tf/s4tf-mnist.html)
- [An introduction to Generative Adversarial Networks in Swift for TensorFlow](https://rickwierenga.com/blog/s4tf/s4tf-gan.html)

Please let me know if this isn’t the right place for this, or if there is a better way to share my experience with the FastAI community. I'd love to do something to give back.

Thanks!