### PR TITLE
Update conda path in GCP tutorial

### DIFF
--- a/docs/start_gcp.md
+++ b/docs/start_gcp.md
@@ -192,7 +192,7 @@ git pull
 You should also update the fastai library:
 
 ``` bash
-sudo /opt/anaconda3/bin/conda install -c fastai fastai
+sudo /opt/conda/bin/conda install -c fastai fastai
 ```
 
 Next, from your [jupyter notebook](http://localhost:8080/tree): click on 'tutorials', 'fastai', 'course-v3', and you should see something like this:


### PR DESCRIPTION
The path to conda found in the latest GCP image has changed. The anaconda3 directory no longer exists in /opt.