### PR TITLE
correct link to image in repo, adding /docs in front of /images

### DIFF
--- a/docs/deployment_flask_gunicorn_docker.md
+++ b/docs/deployment_flask_gunicorn_docker.md
@@ -8,7 +8,7 @@ This is a guide to deploy your trained models created with Fast.ai v2 by combini
 **An example jupyter notebook that trains the model used by the flask app can be accessed here:**
 [Jupyter Notebook](https://github.com/javismiles/bear-detector-flask-deploy/blob/master/resources/model.ipynb)
 
-![Image of cute bear](/images/flask_gunicorn_nginx/cutebear.jpg)
+![Image of cute bear](/docs/images/flask_gunicorn_nginx/cutebear.jpg)
 
 The objective of this project is to deploy a Flask app that uses a model trained with the Fast.ai v2 library following an example in the upcoming book &quot;Deep Learning for Coders with fastai and PyTorch: AI Applications Without a PhD&quot; by Jeremy Howard and Sylvain Gugger.
 


### PR DESCRIPTION
the image I put on repo appears broken, looks like I had to put /docs/images instead of just /images 