### PR TITLE
Docs: Update Google Cloud products and pricing

### DIFF
--- a/docs/start_gcp.md
+++ b/docs/start_gcp.md
@@ -17,26 +17,24 @@ GCP charges separately for the base CPU platform, and the GPU. We have two recom
 
 ### Standard Compute
 
-The base platform we suggest is called `n1-highmem-8`, and costs $0.12 per hour. Attaching a P4 GPU costs $0.26 per hour so both together amount to **$0.38 per hour**. 
+The base platform we suggest is called `n2d-highmem-8`, and costs $0.11 per hour. Attaching a T4 GPU costs $0.11 per hour so both together amount to **$0.22 per hour**. 
 
 ### Budget Compute
 
-If you have a tight budget you might want to go with a cheaper setup. In this case, we suggest a `n1-highmem-4` instance ($0.09 per hour) with a K80 GPU ($0.14 per hour), with a total of **$0.23 per hour**. 
-
-According to our benchmarks, a K80 is 84% slower than a P4 so this setup will roughly double your training time. If this is ok with you, you must follow the budget commands when creating your instance.
+If you have a tight budget you might want to go with a cheaper setup. In this case, we suggest a `n2d-highmem-4` instance ($0.055 per hour) with the same T4 GPU, for a total of **$0.165 per hour**. 
 
 ### Storage
 
-In both cases, by getting the suggested 200GB Standard Disk storage size ([less storage hampers experience](https://cloud.google.com/compute/docs/disks/)), there will be an **additional charge of $9.60 a month**.
+In both cases, by getting the suggested 200GB Standard Disk storage size ([less storage hampers experience](https://cloud.google.com/compute/docs/disks/)), there will be an **additional charge of $8 a month**. The same size in fast SSD storage costs $34 per month.
 
 ### How much will you use this course
 
 Considering that the course requires, over 2 months, 80 hours of homework plus the 2 hours of working through each lesson, we calculated roughly how much you would spend in the course with each of the setups.
 
-- *Standard Compute* + *Storage*: (80+2\*7)\*$0.38 + $9.6*2 =  **$54.92**
-- *Budget Compute* + *Storage*: (80+2\*7)\*$0.23 + $9.6*2 =  **$40.82**
+- *Standard Compute* + *Storage*: (80+2\*7)\*$0.22 + $8*2 =  **$36.68**
+- *Budget Compute* + *Storage*: (80+2\*7)\*$0.165 + $8*2 =  **$31.51**
 
-Even if you were to work on the course twice the time that we suggest as minimum, your expenditure would amount to **$90.64** which is less than 1/3 of the credits GCP gives you. Therefore we suggest to go for the Standard Compute option.
+Even if you were to work on the course twice the time that we suggest as minimum, your expenditure would amount to **$73.36** which is less than 1/4 of the credits GCP gives you. Therefore we suggest to go for the Standard Compute option.
 
 ## Step 1: Creating your account
 
@@ -115,15 +113,15 @@ This gcloud configuration is called [default].
 
 To create the instance we recommend, just copy and paste the following command in your terminal. You can change \$INSTANCE_NAME to any name you want for your instance. 
 
-If you choose the budget compute option, please replace the values of the parameters on the lines with a 'budget:' comment (e.g. replace "n1-highmem-8" by "n1-highmem-4").
+If you choose the budget compute option, please replace the values of the parameters on the lines with a 'budget:' comment (e.g. replace "n2d-highmem-8" by "n2d-highmem-4").
 
 ```bash
 export IMAGE_FAMILY="pytorch-latest-gpu" # or "pytorch-latest-cpu" for non-GPU instances
 export ZONE="us-west1-b"
 export INSTANCE_NAME="my-fastai-instance"
-export INSTANCE_TYPE="n1-highmem-8" # budget: "n1-highmem-4"
+export INSTANCE_TYPE="n2d-highmem-8" # budget: "n2d-highmem-4"
 
-# budget: 'type=nvidia-tesla-k80,count=1'
+# budget: 'type=nvidia-tesla-T4,count=1'
 gcloud compute instances create $INSTANCE_NAME \
         --zone=$ZONE \
         --image-family=$IMAGE_FAMILY \


### PR DESCRIPTION
 - Updates the standard compute setup from `n1-highmem-8` to `n2d-highmem-8` (52 --> 64 GB memory, Intel --> AMD)
 - Updates the budget compute setup from `n1-highmem-4` to `n2d-highmem-4` (26 --> 32 GB memory, Intel --> AMD)
 - Updates both the standard P4 and budget K80 GPU to the cheaper and faster T4 GPU.
 - Updates storage pricing
 - Add an option for fast SSD storage