### PR TITLE
Fixed cannnot call numpy on variable that requires grad error

### DIFF
--- a/nbs/dl1/lesson2-sgd.ipynb
+++ b/nbs/dl1/lesson2-sgd.ipynb
@@ -302,7 +302,7 @@
    ],
    "source": [
     "plt.scatter(x[:,0],y)\n",
-    "plt.scatter(x[:,0],x@a);"
+    "plt.scatter(x[:,0],x@a.detach().numpy());"
    ]
   },
   {


### PR DESCRIPTION
In lesson2-sgd, an error pops up, specifically, cannot call numpy on variable that requires grad. I have included a simple fix by changing x@a to x@a.detach().numpy(). This solves the error.