### PR TITLE
[FIX] switch zeit now to Vercel Now for fastai

### DIFF
--- a/docs/deployment_zeit.md
+++ b/docs/deployment_zeit.md
@@ -1,19 +1,19 @@
 ---
-title: "Deploying on Zeit"
+title: "Deploying on Vercel"
 sidebar: home_sidebar
 ---
 
 ## THIS IS NOT WORKING
 
-*Unfortunately Zeit changed their API in a way that broke all fastai deployments. We suggest using an alternative service, such as render.com*
+*Unfortunately Vercel changed their API in a way that broke all fastai deployments. We suggest using an alternative service, such as render.com*
 
 <img alt="" src="/images/zeit/zeit_now.png" class="screenshot">
 
-This is quick guide to deploy your trained models using the [Now](https://zeit.co/now) service from [Zeit](https://zeit.co/).  This guide comes with a starter app deploying Jeremy's Bear Image Classification model form Lesson 2.
+This is quick guide to deploy your trained models using the [Vercel Now](https://vercel.com/now) service from [Vercel](https://vercel.com/).  This guide comes with a starter app deploying Jeremy's Bear Image Classification model form Lesson 2.
 
 ## One-time setup
 
-### Install Now's CLI (Command Line Interface)
+### Install Vercel Now's CLI (Command Line Interface)
 
 ```bash
 sudo apt install npm # if not already installed
@@ -42,7 +42,7 @@ If you want to just test the deployment initially, you can use Jeremy's bear cla
 
 ### Deploy
 
-On the terminal, make sure you are in the `zeit` directory, then type:
+On the terminal, make sure you are in the `Vercel` directory, then type:
 
 ```bash
 now


### PR DESCRIPTION
- Zeit just rebranded to Vercel and this PR changes the deployment guidelines to deployment for gridsome