### PR TITLE
Small change to the location of conda in GCP docs

### DIFF
--- a/docs/start_gcp.md
+++ b/docs/start_gcp.md
@@ -190,7 +190,7 @@ git pull
 You should also update the fastai library:
 
 ``` bash
-sudo /opt/anaconda3/bin/conda install -c fastai fastai
+sudo /opt/conda/bin/conda install -c fastai fastai
 ```
 
 Next, from your [jupyter notebook](http://localhost:8080/tree): click on 'tutorials', 'fastai', 'course-v3', and you should see something like this:


### PR DESCRIPTION
The location of conda seems to have been updated in the `deeplearning-platform-release` image on Google.

Here's the new location:
```
jupyter@my-fastai-instance:~/tutorials/fastai/course-v3$ which conda
/opt/conda/bin/conda
```