### PR TITLE
Add missing [in_train] variable specification

### DIFF
--- a/nbs/dl2/05b_early_stopping.ipynb
+++ b/nbs/dl2/05b_early_stopping.ipynb
@@ -127,6 +127,7 @@
     "#export\n",
     "class Runner():\n",
     "    def __init__(self, cbs=None, cb_funcs=None):\n",
+    "        self.in_train = False\n",
     "        cbs = listify(cbs)\n",
     "        for cbf in listify(cb_funcs):\n",
     "            cb = cbf()\n",


### PR DESCRIPTION
[in_train] variable is missing in the notebook version of the Runner class. Can cause problems if exported.