### PR TITLE
Fix for the error, IndexError: index 3 is out of bounds for dimension 0 with size 3,  in 05_anneal.ipynb

### DIFF
--- a/nbs/dl2/05_anneal.ipynb
+++ b/nbs/dl2/05_anneal.ipynb
@@ -352,6 +352,7 @@
     "    pcts = torch.cumsum(pcts, 0)\n",
     "    def _inner(pos):\n",
     "        idx = (pos >= pcts).nonzero().max()\n",
+    "        if idx == 2: idx = 1\n",
     "        actual_pos = (pos-pcts[idx]) / (pcts[idx+1]-pcts[idx])\n",
     "        return scheds[idx](actual_pos)\n",
     "    return _inner"


### PR DESCRIPTION
IndexError: index 3 is out of bounds for dimension 0 with size 3

torch.linspace() behaviour differs in different PyTorch versions. 
For example, for T = torch.linspace(0.01, 1, 100),
value of T[99] is 0.99XXXXXX in version 1.4.0
value of T[99] is 1 in torch versions > 1.4.0

Hence modified the function def _inner() by adding 'if idx == 2: idx = 1' to work as expected.