### PR TITLE
last sched error

### DIFF
--- a/nbs/dl2/05_anneal.ipynb
+++ b/nbs/dl2/05_anneal.ipynb
@@ -402,7 +402,7 @@
     }
    ],
    "source": [
-    "plt.plot(a, [sched(o) for o in p])"
+    "plt.plot(a[:-1], [sched(o) for o in p[:-1]])"
    ]
   },
   {


### PR DESCRIPTION
No `pcts[idx+1]` when `pos` reaches the end of range.