### PR TITLE
Small fix on path for fast.ai library update

### DIFF
--- a/docs/update_gcp.md
+++ b/docs/update_gcp.md
@@ -46,7 +46,7 @@ This should give you the latest of the course notebooks. If you modified some of
 ### Update the fastai library
 To update the fastai library, open the terminal like before and type
 ``` bash
-sudo /opt/anaconda3/bin/conda install -c fastai fastai
+sudo /opt/conda/bin/conda install -c fastai fastai
 ```
 
 ### Stop your instance


### PR DESCRIPTION
Running 
```
 sudo /opt/anaconda3/bin/conda install -c fastai fastai
```
resulted in an ```command not found``` error 

Instead running ```sudo /opt/anaconda3/bin/conda install -c fastai fastai``` updated the library.