### PR TITLE
Add requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+fastai
+jupyter


### PR DESCRIPTION
Hello! 

Apologies if this has already come up and there's a reason why it doesn't exist. I wanted to run all the notebooks locally so I could be a bit closer to the code. 

This PR adds a root-level `requirements.txt` file (which can be installed via `pip install -r requirements.txt`). AFAIK there are currently only 2 requirements, `fastai` and `jupyter` (I was using `jupyterlab` but didn't want to complicate things).

I know this seems a bit overkill with only 2 dependencies! I haven't pinned any versions of anything but it might be useful to in the future for consistent environments. 

Thanks