### PR TITLE
Fixing slow and difficult to read operation with simple matmul

### DIFF
--- a/nbs/dl2/02_fully_connected.ipynb
+++ b/nbs/dl2/02_fully_connected.ipynb
@@ -758,7 +758,7 @@
     "def lin_grad(inp, out, w, b):\n",
     "    # grad of matmul with respect to input\n",
     "    inp.g = out.g @ w.t()\n",
-    "    w.g = (inp.unsqueeze(-1) * out.g.unsqueeze(1)).sum(0)\n",
+    "    w.g = inp.T @ out.g\n",
     "    b.g = out.g.sum(0)"
    ]
   },
@@ -925,7 +925,7 @@
     "    def backward(self):\n",
     "        self.inp.g = self.out.g @ self.w.t()\n",
     "        # Creating a giant outer product, just to sum it, is inefficient!\n",
-    "        self.w.g = (self.inp.unsqueeze(-1) * self.out.g.unsqueeze(1)).sum(0)\n",
+    "        self.w.g = self.inp.T @ self.out.g\n",
     "        self.b.g = self.out.g.sum(0)"
    ]
   },

--- a/nbs/dl2/02_fully_connected.ipynb
+++ b/nbs/dl2/02_fully_connected.ipynb
@@ -924,7 +924,6 @@
     "    \n",
     "    def backward(self):\n",
     "        self.inp.g = self.out.g @ self.w.t()\n",
-    "        # Creating a giant outer product, just to sum it, is inefficient!\n",
     "        self.w.g = self.inp.T @ self.out.g\n",
     "        self.b.g = self.out.g.sum(0)"
    ]


### PR DESCRIPTION
The (inp.unsqueeze(-1) * out.g.unsqueeze(1)).sum(0) is actually doing the same thing as inp.T @ out.g, but much slower. 
The only reason for the operation with unsqueeze() is to exercise the broadcasting. 
Compared with %timeit - the method with @ is nearly order of magnitude faster (on my machine)