### PR TITLE
Updated lesson video links

### DIFF
--- a/nbs/dl2/02_fully_connected.ipynb
+++ b/nbs/dl2/02_fully_connected.ipynb
@@ -23,7 +23,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[Jump_to lesson 8 video](https://course.fast.ai/videos/?lesson=8&t=4960)"
+    "[Jump_to lesson 8 video](https://course19.fast.ai/videos/?lesson=8&t=4960)"
    ]
   },
   {
@@ -166,7 +166,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[Jump_to lesson 8 video](https://course.fast.ai/videos/?lesson=8&t=5128)"
+    "[Jump_to lesson 8 video](https://course19.fast.ai/videos/?lesson=8&t=5128)"
    ]
   },
   {
@@ -183,7 +183,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[Tinker practice](https://course.fast.ai/videos/?lesson=8&t=5255)"
+    "[Tinker practice](https://course19.fast.ai/videos/?lesson=8&t=5255)"
    ]
   },
   {
@@ -323,7 +323,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[Jump_to lesson 8 video](https://course.fast.ai/videos/?lesson=8&t=5128)"
+    "[Jump_to lesson 8 video](https://course19.fast.ai/videos/?lesson=8&t=5128)"
    ]
   },
   {
@@ -615,7 +615,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[Jump_to lesson 8 video](https://course.fast.ai/videos/?lesson=8&t=6372)"
+    "[Jump_to lesson 8 video](https://course19.fast.ai/videos/?lesson=8&t=6372)"
    ]
   },
   {
@@ -724,7 +724,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[Jump_to lesson 8 video](https://course.fast.ai/videos/?lesson=8&t=6493)"
+    "[Jump_to lesson 8 video](https://course19.fast.ai/videos/?lesson=8&t=6493)"
    ]
   },
   {
@@ -890,7 +890,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[Jump_to lesson 8 video](https://course.fast.ai/videos/?lesson=8&t=7112)"
+    "[Jump_to lesson 8 video](https://course19.fast.ai/videos/?lesson=8&t=7112)"
    ]
   },
   {
@@ -1177,7 +1177,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[Jump_to lesson 8 video](https://course.fast.ai/videos/?lesson=8&t=7484)"
+    "[Jump_to lesson 8 video](https://course19.fast.ai/videos/?lesson=8&t=7484)"
    ]
   },
   {


### PR DESCRIPTION
The current links redirects to course v4 (2020 version).
This proposed changes updates the link to course19 which redirects to the correct lesson video.

