### PR TITLE
fix(common): add missing all to import

### DIFF
--- a/nbs/dl1/lesson1-pets.ipynb
+++ b/nbs/dl1/lesson1-pets.ipynb
@@ -42,7 +42,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from fastai.vision import *\n",
+    "from fastai.vision.all import *\n",
     "from fastai.metrics import error_rate"
    ]
   },


### PR DESCRIPTION
This imports all from the fastasi vision library.
Previously an error would occur when calling untar_data.

Support thread:
https://forums.fast.ai/t/name-untar-data-is-not-defined/36006